### PR TITLE
Parallel/files

### DIFF
--- a/storage/cli/variants.py
+++ b/storage/cli/variants.py
@@ -158,7 +158,7 @@ def load_snippy(ctx, snippy_dir: Path, reference_file: Path, build_tree: bool, a
     reference_file = Path(reference_file)
     click.echo(f'Loading {snippy_dir}')
     sample_dirs = [snippy_dir / d for d in listdir(snippy_dir) if path.isdir(snippy_dir / d)]
-    variants_reader = SnippyVariantsReader(sample_dirs)
+    variants_reader = SnippyVariantsReader.create(sample_dirs)
 
     load_variants_common(ctx=ctx, variants_reader=variants_reader, reference_file=reference_file,
                          input=snippy_dir, build_tree=build_tree, align_type=align_type, threads=threads,
@@ -192,7 +192,7 @@ def load_vcf(ctx, vcf_fofns: Path, reference_file: Path, build_tree: bool, align
         if not pd.isna(row['Mask File']):
             mask_files_map[row['Sample']] = row['Mask File']
 
-    variants_reader = VcfVariantsReader(sample_vcf_map=sample_vcf_map,
+    variants_reader = VcfVariantsReader.create_from_sequence_masks(sample_vcf_map=sample_vcf_map,
                                         masked_genomic_files_map=mask_files_map)
 
     load_variants_common(ctx=ctx, variants_reader=variants_reader, reference_file=reference_file,

--- a/storage/cli/variants.py
+++ b/storage/cli/variants.py
@@ -4,6 +4,8 @@ import sys
 from os import path, listdir
 from pathlib import Path
 from typing import List
+from functools import partial
+from tempfile import TemporaryDirectory
 
 import click
 import click_config_file
@@ -33,12 +35,16 @@ from storage.variant.service.ReferenceService import ReferenceService
 from storage.variant.service.SampleService import SampleService
 from storage.variant.service.TreeService import TreeService
 from storage.variant.service.VariationService import VariationService
+from storage.variant.io.processor.MultipleProcessSampleFilesProcessor import MultipleProcessSampleFilesProcessor
+from storage.variant.io.processor.NullSampleFilesProcessor import NullSampleFilesProcessor
 from storage.variant.util import get_genome_name
 
 logger = logging.getLogger('storage')
-num_cores = multiprocessing.cpu_count()
+max_cores = multiprocessing.cpu_count()
 
 LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
+
+click.option = partial(click.option, show_default=True)
 
 
 @click.group()
@@ -46,11 +52,13 @@ LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
 @click.option('--database-connection', help='A connection string for the database.')
 @click.option('--database-dir', help='The root directory for the database files.',
               type=click.Path())
+@click.option('--ncores', help='Number of cores for any parallel processing', default=max_cores,
+              type=click.IntRange(min=1, max=max_cores))
 @click.option('--log-level', default='WARNING', help='Sets the log level', type=click.Choice(LOG_LEVELS))
 @click_config_file.configuration_option(provider=yaml_config_provider,
                                         config_file_name='config.yaml',
                                         implicit=True)
-def main(ctx, database_connection, database_dir, log_level):
+def main(ctx, database_connection, database_dir, ncores, log_level):
     ctx.ensure_object(dict)
 
     if log_level == 'INFO' or log_level == 'DEBUG':
@@ -103,6 +111,7 @@ def main(ctx, database_connection, database_dir, log_level):
     ctx.obj['mlst_service'] = mlst_service
     ctx.obj['mlst_query_service'] = mlst_query_service
     ctx.obj['kmer_query_service'] = kmer_query_service
+    ctx.obj['ncores'] = ncores
 
 
 @main.group()
@@ -111,12 +120,13 @@ def load(ctx):
     pass
 
 
-def load_variants_common(ctx, variants_reader, reference_file, input, build_tree, align_type, threads,
+def load_variants_common(ctx, variants_reader, reference_file, input, build_tree, align_type,
                          extra_tree_params: str):
     reference_service = ctx.obj['reference_service']
     variation_service = ctx.obj['variation_service']
     sample_service = ctx.obj['sample_service']
     tree_service = ctx.obj['tree_service']
+    ncores = ctx.obj['ncores']
 
     try:
         reference_service.add_reference_genome(reference_file)
@@ -136,7 +146,7 @@ def load_variants_common(ctx, variants_reader, reference_file, input, build_tree
         if build_tree:
             tree_service.rebuild_tree(reference_name=reference_name,
                                       align_type=align_type,
-                                      num_cores=threads,
+                                      num_cores=ncores,
                                       extra_params=extra_tree_params)
             click.echo('Finished building tree of all samples')
 
@@ -148,21 +158,28 @@ def load_variants_common(ctx, variants_reader, reference_file, input, build_tree
 @click.option('--build-tree/--no-build-tree', default=False, help='Builds tree of all samples after loading')
 @click.option('--align-type', help=f'The type of alignment to generate', default='core',
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
-@click.option('--threads', help='Threads for building tree', default=1,
-              type=click.IntRange(min=1, max=num_cores))
 @click.option('--extra-tree-params', help='Extra parameters to tree-building software',
               default=None)
-def load_snippy(ctx, snippy_dir: Path, reference_file: Path, build_tree: bool, align_type: str, threads: int,
-                extra_tree_params: str):
+def load_snippy(ctx, snippy_dir: Path, reference_file: Path, build_tree: bool, align_type: str, extra_tree_params: str):
+    ncores = ctx.obj['ncores']
+
     snippy_dir = Path(snippy_dir)
     reference_file = Path(reference_file)
     click.echo(f'Loading {snippy_dir}')
     sample_dirs = [snippy_dir / d for d in listdir(snippy_dir) if path.isdir(snippy_dir / d)]
-    variants_reader = SnippyVariantsReader.create(sample_dirs)
 
-    load_variants_common(ctx=ctx, variants_reader=variants_reader, reference_file=reference_file,
-                         input=snippy_dir, build_tree=build_tree, align_type=align_type, threads=threads,
-                         extra_tree_params=extra_tree_params)
+    with TemporaryDirectory() as preprocess_dir:
+        if ncores > 1:
+            file_processor = MultipleProcessSampleFilesProcessor(preprocess_dir=Path(preprocess_dir),
+                                                                 processing_cores=ncores)
+        else:
+            file_processor = NullSampleFilesProcessor()
+
+        variants_reader = SnippyVariantsReader.create(sample_dirs, sample_files_processor=file_processor)
+
+        load_variants_common(ctx=ctx, variants_reader=variants_reader, reference_file=reference_file,
+                             input=snippy_dir, build_tree=build_tree, align_type=align_type,
+                             extra_tree_params=extra_tree_params)
 
 
 @load.command(name='vcf')
@@ -172,13 +189,11 @@ def load_snippy(ctx, snippy_dir: Path, reference_file: Path, build_tree: bool, a
 @click.option('--build-tree/--no-build-tree', default=False, help='Builds tree of all samples after loading')
 @click.option('--align-type', help=f'The type of alignment to generate', default='core',
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
-@click.option('--threads', help='Threads for building tree', default=1,
-              type=click.IntRange(min=1, max=num_cores))
 @click.option('--extra-tree-params', help='Extra parameters to tree-building software',
               default=None)
-def load_vcf(ctx, vcf_fofns: Path, reference_file: Path, build_tree: bool, align_type: str, threads: int,
-             extra_tree_params: str):
+def load_vcf(ctx, vcf_fofns: Path, reference_file: Path, build_tree: bool, align_type: str, extra_tree_params: str):
     reference_file = Path(reference_file)
+    ncores = ctx.obj['ncores']
 
     click.echo(f'Loading files listed in {vcf_fofns}')
     sample_vcf_map = {}
@@ -192,12 +207,20 @@ def load_vcf(ctx, vcf_fofns: Path, reference_file: Path, build_tree: bool, align
         if not pd.isna(row['Mask File']):
             mask_files_map[row['Sample']] = row['Mask File']
 
-    variants_reader = VcfVariantsReader.create_from_sequence_masks(sample_vcf_map=sample_vcf_map,
-                                        masked_genomic_files_map=mask_files_map)
+    with TemporaryDirectory() as preprocess_dir:
+        if ncores > 1:
+            file_processor = MultipleProcessSampleFilesProcessor(preprocess_dir=Path(preprocess_dir),
+                                                                 processing_cores=ncores)
+        else:
+            file_processor = NullSampleFilesProcessor()
 
-    load_variants_common(ctx=ctx, variants_reader=variants_reader, reference_file=reference_file,
-                         input=Path(vcf_fofns), build_tree=build_tree, align_type=align_type, threads=threads,
-                         extra_tree_params=extra_tree_params)
+        variants_reader = VcfVariantsReader.create_from_sequence_masks(sample_vcf_map=sample_vcf_map,
+                                                                       masked_genomic_files_map=mask_files_map,
+                                                                       sample_files_processor=file_processor)
+
+        load_variants_common(ctx=ctx, variants_reader=variants_reader, reference_file=reference_file,
+                             input=Path(vcf_fofns), build_tree=build_tree, align_type=align_type,
+                             extra_tree_params=extra_tree_params)
 
 
 @load.command(name='kmer')
@@ -370,16 +393,15 @@ def alignment(ctx, output_file: Path, reference_name: str, align_type: str, samp
               type=click.Choice(TreeService.TREE_BUILD_TYPES))
 @click.option('--sample', help='Sample to include in tree (can list more than one).',
               multiple=True, type=str)
-@click.option('--threads', help='Threads for building tree', default=1,
-              type=click.IntRange(min=1, max=num_cores))
 @click.option('--extra-params', help='Extra parameters to tree-building software',
               default=None)
 def tree(ctx, output_file: Path, reference_name: str, align_type: str,
-         tree_build_type: str, sample: List[str], threads: int, extra_params: str):
+         tree_build_type: str, sample: List[str], extra_params: str):
     alignment_service = ctx.obj['alignment_service']
     tree_service = ctx.obj['tree_service']
     reference_service = ctx.obj['reference_service']
     sample_service = ctx.obj['sample_service']
+    ncores = ctx.obj['ncores']
 
     if not reference_service.exists_reference_genome(reference_name):
         logger.error(f'Reference genome [{reference_name}] does not exist')
@@ -403,7 +425,7 @@ def tree(ctx, output_file: Path, reference_name: str, align_type: str,
     log_file = f'{output_file}.log'
 
     tree_data, out = tree_service.build_tree(alignment_data, tree_build_type=tree_build_type,
-                                             num_cores=threads, align_type=align_type, extra_params=extra_params)
+                                             num_cores=ncores, align_type=align_type, extra_params=extra_params)
     tree_data.write(outfile=output_file)
     click.echo(f'Wrote tree to [{output_file}]')
     with open(log_file, 'w') as log:
@@ -422,13 +444,12 @@ def rebuild(ctx):
 @click.argument('reference', type=str, nargs=-1)
 @click.option('--align-type', help=f'The type of alignment to use for generating the tree', default='core',
               type=click.Choice(CoreAlignmentService.ALIGN_TYPES))
-@click.option('--threads', help='Threads for building tree', default=1,
-              type=click.IntRange(min=1, max=num_cores))
 @click.option('--extra-params', help='Extra parameters to tree-building software',
               default=None)
-def rebuild_tree(ctx, reference: List[str], align_type: str, threads: int, extra_params: str):
+def rebuild_tree(ctx, reference: List[str], align_type: str, extra_params: str):
     tree_service = ctx.obj['tree_service']
     reference_service = ctx.obj['reference_service']
+    ncores = ctx.obj['ncores']
 
     if len(reference) == 0:
         logger.error('Must define name of reference genome to use. '
@@ -444,7 +465,7 @@ def rebuild_tree(ctx, reference: List[str], align_type: str, threads: int, extra
         logger.info(f'Started rebuilding tree for reference genome [{reference_name}]')
         tree_service.rebuild_tree(reference_name=reference_name,
                                   align_type=align_type,
-                                  num_cores=threads,
+                                  num_cores=ncores,
                                   extra_params=extra_params)
         logger.info(f'Finished rebuilding tree')
 

--- a/storage/cli/variants.py
+++ b/storage/cli/variants.py
@@ -1,11 +1,11 @@
 import logging
 import multiprocessing
 import sys
+from functools import partial
 from os import path, listdir
 from pathlib import Path
-from typing import List
-from functools import partial
 from tempfile import TemporaryDirectory
+from typing import List
 
 import click
 import click_config_file
@@ -22,6 +22,8 @@ from storage.variant.io.mlst.MLSTSistrReader import MLSTSistrReader
 from storage.variant.io.mlst.MLSTTSeemannFeaturesReader import MLSTTSeemannFeaturesReader
 from storage.variant.io.mutation.SnippyVariantsReader import SnippyVariantsReader
 from storage.variant.io.mutation.VcfVariantsReader import VcfVariantsReader
+from storage.variant.io.processor.MultipleProcessSampleFilesProcessor import MultipleProcessSampleFilesProcessor
+from storage.variant.io.processor.NullSampleFilesProcessor import NullSampleFilesProcessor
 from storage.variant.model.QueryFeatureMLST import QueryFeatureMLST
 from storage.variant.model.QueryFeatureMutation import QueryFeatureMutation
 from storage.variant.service import DatabaseConnection, EntityExistsError
@@ -35,8 +37,6 @@ from storage.variant.service.ReferenceService import ReferenceService
 from storage.variant.service.SampleService import SampleService
 from storage.variant.service.TreeService import TreeService
 from storage.variant.service.VariationService import VariationService
-from storage.variant.io.processor.MultipleProcessSampleFilesProcessor import MultipleProcessSampleFilesProcessor
-from storage.variant.io.processor.NullSampleFilesProcessor import NullSampleFilesProcessor
 from storage.variant.util import get_genome_name
 
 logger = logging.getLogger('storage')

--- a/storage/test/integration/variant/io/__init__.py
+++ b/storage/test/integration/variant/io/__init__.py
@@ -1,6 +1,7 @@
+from pathlib import Path
+
 import pandas as pd
 import vcf
-from pathlib import Path
 
 
 def read_vcf_df(file: Path) -> pd.DataFrame:

--- a/storage/test/integration/variant/io/__init__.py
+++ b/storage/test/integration/variant/io/__init__.py
@@ -1,0 +1,11 @@
+import pandas as pd
+import vcf
+from pathlib import Path
+
+
+def read_vcf_df(file: Path) -> pd.DataFrame:
+    reader = vcf.Reader(filename=str(file))
+    df = pd.DataFrame([vars(r) for r in reader])
+    df['TYPE'] = df['INFO'].apply(lambda x: x['TYPE'][0] if 'TYPE' in x else pd.NA)
+
+    return df

--- a/storage/test/integration/variant/io/test_NucleotideSampleFilesSequenceMask.py
+++ b/storage/test/integration/variant/io/test_NucleotideSampleFilesSequenceMask.py
@@ -2,7 +2,6 @@ import pytest
 from typing import Dict
 from pathlib import Path
 from tempfile import TemporaryDirectory
-import os
 
 from storage.test.integration.variant.io import read_vcf_df
 from storage.test.integration.variant import regular_vcf_dir, data_dir
@@ -28,37 +27,33 @@ def files_map():
 
 
 def test_get_vcf_file_no_preprocess(files_map: Dict[str, Dict[str, Path]]):
-    with TemporaryDirectory() as tmp_dir:
-        sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
-                                                         vcf_file=files_map['SampleA']['vcf'],
-                                                         sample_mask_sequence=files_map['SampleA']['mask'],
-                                                         tmp_dir=Path(tmp_dir))
-        vcf_file, index_file = sample_files.get_vcf_file(ignore_preprocessed=True)
-        assert vcf_file.exists()
-        assert index_file is None
-        df = read_vcf_df(vcf_file)
-        assert len(df[df['TYPE'].isna()]) > 0
+    sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
+                                                     vcf_file=files_map['SampleA']['vcf'],
+                                                     sample_mask_sequence=files_map['SampleA']['mask'])
+    vcf_file, index_file = sample_files.get_vcf_file(ignore_preprocessed=True)
+    assert vcf_file.exists()
+    assert index_file is None
+    df = read_vcf_df(vcf_file)
+    assert len(df[df['TYPE'].isna()]) > 0
 
 
 def test_get_sample_mask_no_preprocess(files_map: Dict[str, Dict[str, Path]]):
-    with TemporaryDirectory() as tmp_dir:
-        sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
-                                                         vcf_file=files_map['SampleA']['vcf'],
-                                                         sample_mask_sequence=files_map['SampleA']['mask'],
-                                                         tmp_dir=Path(tmp_dir))
-        with pytest.raises(Exception) as execinfo:
-            sample_files.get_mask()
-        assert 'Sample mask file is not preprocessed for sample' in str(execinfo.value)
+    sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
+                                                     vcf_file=files_map['SampleA']['vcf'],
+                                                     sample_mask_sequence=files_map['SampleA']['mask'])
+    with pytest.raises(Exception) as execinfo:
+        sample_files.get_mask()
+    assert 'Sample mask file is not preprocessed for sample' in str(execinfo.value)
 
 
 def test_get_sample_mask_after_preprocess(files_map: Dict[str, Dict[str, Path]]):
-    with TemporaryDirectory() as tmp_dir:
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
         sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
                                                          vcf_file=files_map['SampleA']['vcf'],
-                                                         sample_mask_sequence=files_map['SampleA']['mask'],
-                                                         tmp_dir=Path(tmp_dir))
+                                                         sample_mask_sequence=files_map['SampleA']['mask'])
         assert not sample_files.is_preprocessed()
-        processed_sample_files = sample_files.preprocess()
+        processed_sample_files = sample_files.preprocess(tmp_dir)
         assert processed_sample_files.is_preprocessed()
         mask = processed_sample_files.get_mask()
         assert 437 == len(mask)
@@ -66,48 +61,48 @@ def test_get_sample_mask_after_preprocess(files_map: Dict[str, Dict[str, Path]])
 
 
 def test_get_sample_mask_double_preprocess(files_map: Dict[str, Dict[str, Path]]):
-    with TemporaryDirectory() as tmp_dir:
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
         sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
                                                          vcf_file=files_map['SampleA']['vcf'],
-                                                         sample_mask_sequence=files_map['SampleA']['mask'],
-                                                         tmp_dir=Path(tmp_dir))
+                                                         sample_mask_sequence=files_map['SampleA']['mask'])
         assert not sample_files.is_preprocessed()
-        processed_sample_files = sample_files.preprocess()
+        processed_sample_files = sample_files.preprocess(tmp_dir)
         assert processed_sample_files.is_preprocessed()
         mask = processed_sample_files.get_mask()
         assert 437 == len(mask)
         assert {'reference'} == mask.sequence_names()
 
-        processed_sample_files_2 = processed_sample_files.preprocess()
-        assert processed_sample_files_2.is_preprocessed()
-        mask_2 = processed_sample_files_2.get_mask()
-        assert 437 == len(mask)
-        assert {'reference'} == mask_2.sequence_names()
+        with TemporaryDirectory() as tmp_dir_2_str:
+            tmp_dir_2 = Path(tmp_dir_2_str)
+            processed_sample_files_2 = sample_files.preprocess(tmp_dir_2)
+            assert processed_sample_files_2.is_preprocessed()
+            mask_2 = processed_sample_files_2.get_mask()
+            assert 437 == len(mask)
+            assert {'reference'} == mask_2.sequence_names()
 
 
 def test_get_vcf_file_no_preprocess_exception(files_map: Dict[str, Dict[str, Path]]):
-    with TemporaryDirectory() as tmp_dir:
-        sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
-                                                         vcf_file=files_map['SampleA']['vcf'],
-                                                         sample_mask_sequence=files_map['SampleA']['mask'],
-                                                         tmp_dir=Path(tmp_dir))
-        with pytest.raises(Exception) as execinfo:
-            sample_files.get_vcf_file()
-        assert 'VCF file for sample' in str(execinfo.value)
+    sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
+                                                     vcf_file=files_map['SampleA']['vcf'],
+                                                     sample_mask_sequence=files_map['SampleA']['mask'])
+    with pytest.raises(Exception) as execinfo:
+        sample_files.get_vcf_file()
+    assert 'VCF file for sample' in str(execinfo.value)
 
 
 def test_get_vcf_file_with_preprocess(files_map: Dict[str, Dict[str, Path]]):
-    with TemporaryDirectory() as tmp_dir:
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
         sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
                                                          vcf_file=files_map['SampleA']['vcf'],
-                                                         sample_mask_sequence=files_map['SampleA']['mask'],
-                                                         tmp_dir=Path(tmp_dir))
+                                                         sample_mask_sequence=files_map['SampleA']['mask'])
         assert not sample_files.is_preprocessed()
         with pytest.raises(Exception) as execinfo:
             sample_files.get_vcf_file()
         assert 'VCF file for sample' in str(execinfo.value)
 
-        processed_sample_files = sample_files.preprocess()
+        processed_sample_files = sample_files.preprocess(tmp_dir)
         assert processed_sample_files.is_preprocessed()
 
         vcf_file, index_file = processed_sample_files.get_vcf_file()
@@ -124,19 +119,17 @@ def test_get_vcf_file_with_preprocess(files_map: Dict[str, Dict[str, Path]]):
 
 
 def test_get_vcf_file_double_preprocess(files_map: Dict[str, Dict[str, Path]]):
-    with TemporaryDirectory() as tmp_dir:
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
         sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
                                                          vcf_file=files_map['SampleA']['vcf'],
-                                                         sample_mask_sequence=files_map['SampleA']['mask'],
-                                                         tmp_dir=Path(tmp_dir))
+                                                         sample_mask_sequence=files_map['SampleA']['mask'])
         assert not sample_files.is_preprocessed()
-        processed_sample_files = sample_files.preprocess()
+        processed_sample_files = sample_files.preprocess(tmp_dir)
         assert processed_sample_files.is_preprocessed()
-        vcf_file, index_file = processed_sample_files.get_vcf_file()
+        processed_sample_files.get_vcf_file()
 
-        processed_sample_files_2 = processed_sample_files.preprocess()
-        assert processed_sample_files_2.is_preprocessed()
-        vcf_file_2, index_file_2 = processed_sample_files_2.get_vcf_file()
-
-        assert vcf_file == vcf_file_2
-        assert index_file == index_file_2
+        with TemporaryDirectory() as tmp_dir_2_str:
+            tmp_dir_2 = Path(tmp_dir_2_str)
+            processed_sample_files_2 = sample_files.preprocess(tmp_dir_2)
+            assert processed_sample_files_2.is_preprocessed()

--- a/storage/test/integration/variant/io/test_NucleotideSampleFilesSequenceMask.py
+++ b/storage/test/integration/variant/io/test_NucleotideSampleFilesSequenceMask.py
@@ -1,10 +1,11 @@
-import pytest
-from typing import Dict
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Dict
 
-from storage.test.integration.variant.io import read_vcf_df
+import pytest
+
 from storage.test.integration.variant import regular_vcf_dir, data_dir
+from storage.test.integration.variant.io import read_vcf_df
 from storage.variant.io.mutation.NucleotideSampleFilesSequenceMask import NucleotideSampleFilesSequenceMask
 
 

--- a/storage/test/integration/variant/io/test_NucleotideSampleFilesSequenceMask.py
+++ b/storage/test/integration/variant/io/test_NucleotideSampleFilesSequenceMask.py
@@ -28,8 +28,8 @@ def files_map():
 
 def test_get_vcf_file_no_preprocess(files_map: Dict[str, Dict[str, Path]]):
     sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
-                                                     vcf_file=files_map['SampleA']['vcf'],
-                                                     sample_mask_sequence=files_map['SampleA']['mask'])
+                                                            vcf_file=files_map['SampleA']['vcf'],
+                                                            sample_mask_sequence=files_map['SampleA']['mask'])
     vcf_file, index_file = sample_files.get_vcf_file(ignore_preprocessed=True)
     assert vcf_file.exists()
     assert index_file is None
@@ -39,8 +39,17 @@ def test_get_vcf_file_no_preprocess(files_map: Dict[str, Dict[str, Path]]):
 
 def test_get_sample_mask_no_preprocess(files_map: Dict[str, Dict[str, Path]]):
     sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
-                                                     vcf_file=files_map['SampleA']['vcf'],
-                                                     sample_mask_sequence=files_map['SampleA']['mask'])
+                                                            vcf_file=files_map['SampleA']['vcf'],
+                                                            sample_mask_sequence=files_map['SampleA']['mask'])
+    with pytest.raises(Exception) as execinfo:
+        sample_files.get_mask()
+    assert 'Sample mask file is not preprocessed for sample' in str(execinfo.value)
+
+
+def test_get_empty_sample_mask_no_preprocess(files_map: Dict[str, Dict[str, Path]]):
+    sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
+                                                            vcf_file=files_map['SampleA']['vcf'],
+                                                            sample_mask_sequence=None)
     with pytest.raises(Exception) as execinfo:
         sample_files.get_mask()
     assert 'Sample mask file is not preprocessed for sample' in str(execinfo.value)
@@ -50,8 +59,8 @@ def test_get_sample_mask_after_preprocess(files_map: Dict[str, Dict[str, Path]])
     with TemporaryDirectory() as tmp_dir_str:
         tmp_dir = Path(tmp_dir_str)
         sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
-                                                         vcf_file=files_map['SampleA']['vcf'],
-                                                         sample_mask_sequence=files_map['SampleA']['mask'])
+                                                                vcf_file=files_map['SampleA']['vcf'],
+                                                                sample_mask_sequence=files_map['SampleA']['mask'])
         assert not sample_files.is_preprocessed()
         processed_sample_files = sample_files.persist(tmp_dir)
         assert processed_sample_files.is_preprocessed()
@@ -63,12 +72,27 @@ def test_get_sample_mask_after_preprocess(files_map: Dict[str, Dict[str, Path]])
         assert mask_file.parent == tmp_dir
 
 
+def test_get_sample_empty_mask_after_preprocess(files_map: Dict[str, Dict[str, Path]]):
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
+                                                                vcf_file=files_map['SampleA']['vcf'])
+        assert not sample_files.is_preprocessed()
+        processed_sample_files = sample_files.persist(tmp_dir)
+        assert processed_sample_files.is_preprocessed()
+        mask_file = processed_sample_files.get_mask_file()
+        assert mask_file.exists()
+        assert mask_file.parent == tmp_dir
+        mask = processed_sample_files.get_mask()
+        assert mask.is_empty()
+
+
 def test_get_sample_mask_double_preprocess(files_map: Dict[str, Dict[str, Path]]):
     with TemporaryDirectory() as tmp_dir_str:
         tmp_dir = Path(tmp_dir_str)
         sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
-                                                         vcf_file=files_map['SampleA']['vcf'],
-                                                         sample_mask_sequence=files_map['SampleA']['mask'])
+                                                                vcf_file=files_map['SampleA']['vcf'],
+                                                                sample_mask_sequence=files_map['SampleA']['mask'])
         assert not sample_files.is_preprocessed()
         processed_sample_files = sample_files.persist(tmp_dir)
         assert processed_sample_files.is_preprocessed()
@@ -94,8 +118,8 @@ def test_get_sample_mask_double_preprocess(files_map: Dict[str, Dict[str, Path]]
 
 def test_get_vcf_file_no_preprocess_exception(files_map: Dict[str, Dict[str, Path]]):
     sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
-                                                     vcf_file=files_map['SampleA']['vcf'],
-                                                     sample_mask_sequence=files_map['SampleA']['mask'])
+                                                            vcf_file=files_map['SampleA']['vcf'],
+                                                            sample_mask_sequence=files_map['SampleA']['mask'])
     with pytest.raises(Exception) as execinfo:
         sample_files.get_vcf_file()
     assert 'VCF file for sample' in str(execinfo.value)
@@ -105,8 +129,8 @@ def test_get_vcf_file_with_preprocess(files_map: Dict[str, Dict[str, Path]]):
     with TemporaryDirectory() as tmp_dir_str:
         tmp_dir = Path(tmp_dir_str)
         sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
-                                                         vcf_file=files_map['SampleA']['vcf'],
-                                                         sample_mask_sequence=files_map['SampleA']['mask'])
+                                                                vcf_file=files_map['SampleA']['vcf'],
+                                                                sample_mask_sequence=files_map['SampleA']['mask'])
         assert not sample_files.is_preprocessed()
         with pytest.raises(Exception) as execinfo:
             sample_files.get_vcf_file()
@@ -135,8 +159,8 @@ def test_get_vcf_file_double_preprocess(files_map: Dict[str, Dict[str, Path]]):
     with TemporaryDirectory() as tmp_dir_str:
         tmp_dir = Path(tmp_dir_str)
         sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
-                                                         vcf_file=files_map['SampleA']['vcf'],
-                                                         sample_mask_sequence=files_map['SampleA']['mask'])
+                                                                vcf_file=files_map['SampleA']['vcf'],
+                                                                sample_mask_sequence=files_map['SampleA']['mask'])
         assert not sample_files.is_preprocessed()
         processed_sample_files = sample_files.persist(tmp_dir)
         assert processed_sample_files.is_preprocessed()

--- a/storage/test/integration/variant/io/test_NucleotideSampleFilesSequenceMask.py
+++ b/storage/test/integration/variant/io/test_NucleotideSampleFilesSequenceMask.py
@@ -31,7 +31,7 @@ def test_get_vcf_file_no_preprocess(files_map: Dict[str, Dict[str, Path]]):
     with TemporaryDirectory() as tmp_dir:
         sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
                                                          vcf_file=files_map['SampleA']['vcf'],
-                                                         sample_mask=files_map['SampleA']['mask'],
+                                                         sample_mask_sequence=files_map['SampleA']['mask'],
                                                          tmp_dir=Path(tmp_dir))
         vcf_file, index_file = sample_files.get_vcf_file(ignore_preprocessed=True)
         assert vcf_file.exists()
@@ -40,11 +40,56 @@ def test_get_vcf_file_no_preprocess(files_map: Dict[str, Dict[str, Path]]):
         assert len(df[df['TYPE'].isna()]) > 0
 
 
+def test_get_sample_mask_no_preprocess(files_map: Dict[str, Dict[str, Path]]):
+    with TemporaryDirectory() as tmp_dir:
+        sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
+                                                         vcf_file=files_map['SampleA']['vcf'],
+                                                         sample_mask_sequence=files_map['SampleA']['mask'],
+                                                         tmp_dir=Path(tmp_dir))
+        with pytest.raises(Exception) as execinfo:
+            sample_files.get_mask()
+        assert 'Sample mask file is not preprocessed for sample' in str(execinfo.value)
+
+
+def test_get_sample_mask_after_preprocess(files_map: Dict[str, Dict[str, Path]]):
+    with TemporaryDirectory() as tmp_dir:
+        sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
+                                                         vcf_file=files_map['SampleA']['vcf'],
+                                                         sample_mask_sequence=files_map['SampleA']['mask'],
+                                                         tmp_dir=Path(tmp_dir))
+        assert not sample_files.is_preprocessed()
+        processed_sample_files = sample_files.preprocess()
+        assert processed_sample_files.is_preprocessed()
+        mask = processed_sample_files.get_mask()
+        assert 437 == len(mask)
+        assert {'reference'} == mask.sequence_names()
+
+
+def test_get_sample_mask_double_preprocess(files_map: Dict[str, Dict[str, Path]]):
+    with TemporaryDirectory() as tmp_dir:
+        sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
+                                                         vcf_file=files_map['SampleA']['vcf'],
+                                                         sample_mask_sequence=files_map['SampleA']['mask'],
+                                                         tmp_dir=Path(tmp_dir))
+        assert not sample_files.is_preprocessed()
+        processed_sample_files = sample_files.preprocess()
+        assert processed_sample_files.is_preprocessed()
+        mask = processed_sample_files.get_mask()
+        assert 437 == len(mask)
+        assert {'reference'} == mask.sequence_names()
+
+        processed_sample_files_2 = processed_sample_files.preprocess()
+        assert processed_sample_files_2.is_preprocessed()
+        mask_2 = processed_sample_files_2.get_mask()
+        assert 437 == len(mask)
+        assert {'reference'} == mask_2.sequence_names()
+
+
 def test_get_vcf_file_no_preprocess_exception(files_map: Dict[str, Dict[str, Path]]):
     with TemporaryDirectory() as tmp_dir:
         sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
                                                          vcf_file=files_map['SampleA']['vcf'],
-                                                         sample_mask=files_map['SampleA']['mask'],
+                                                         sample_mask_sequence=files_map['SampleA']['mask'],
                                                          tmp_dir=Path(tmp_dir))
         with pytest.raises(Exception) as execinfo:
             sample_files.get_vcf_file()
@@ -55,7 +100,7 @@ def test_get_vcf_file_with_preprocess(files_map: Dict[str, Dict[str, Path]]):
     with TemporaryDirectory() as tmp_dir:
         sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
                                                          vcf_file=files_map['SampleA']['vcf'],
-                                                         sample_mask=files_map['SampleA']['mask'],
+                                                         sample_mask_sequence=files_map['SampleA']['mask'],
                                                          tmp_dir=Path(tmp_dir))
         assert not sample_files.is_preprocessed()
         with pytest.raises(Exception) as execinfo:
@@ -82,7 +127,7 @@ def test_get_vcf_file_double_preprocess(files_map: Dict[str, Dict[str, Path]]):
     with TemporaryDirectory() as tmp_dir:
         sample_files = NucleotideSampleFilesSequenceMask.create(sample_name='SampleA',
                                                          vcf_file=files_map['SampleA']['vcf'],
-                                                         sample_mask=files_map['SampleA']['mask'],
+                                                         sample_mask_sequence=files_map['SampleA']['mask'],
                                                          tmp_dir=Path(tmp_dir))
         assert not sample_files.is_preprocessed()
         processed_sample_files = sample_files.preprocess()

--- a/storage/test/integration/variant/io/test_SnippyVariantReader.py
+++ b/storage/test/integration/variant/io/test_SnippyVariantReader.py
@@ -14,7 +14,7 @@ sample_dirs_empty = [data_dir_empty / d for d in listdir(data_dir_empty) if path
 @pytest.fixture
 def setup() -> Dict[str, Any]:
     return {
-        'reader': SnippyVariantsReader(sample_dirs)
+        'reader': SnippyVariantsReader.create(sample_dirs)
     }
 
 
@@ -27,6 +27,10 @@ def test_read_vcf(setup):
 
     assert {'snps.vcf.gz'} == set(df['FILE'].tolist()), 'Incorrect filename'
     assert {'SampleA'} == set(df['SAMPLE'].tolist()), 'Incorrect sample name'
+
+    v = df[df['POS'] == 461]
+    assert 'AAAT' == v['REF'].values[0], 'Incorrect reference'
+    assert 'G' == v['ALT'].values[0], 'Incorrect alt'
 
     v = df[df['POS'] == 1048]
     assert 'C' == v['REF'].values[0], 'Incorrect reference'
@@ -46,14 +50,6 @@ def test_get_variants_table(setup):
 
     assert 129 == len(df), 'Data has incorrect length'
     assert {'SampleA', 'SampleB', 'SampleC'} == set(df['SAMPLE'].tolist()), 'Incorrect sample names'
-
-
-def test_read_genomic_masks_from_file(setup):
-    sequence_file = data_dir / 'SampleA' / 'snps.aligned.fa'
-
-    genomic_mask = setup['reader'].read_genomic_masks_from_file(sequence_file)
-
-    assert 437 == len(genomic_mask)
 
 
 def test_get_genomic_masks(setup):
@@ -79,13 +75,13 @@ def test_get_samples_list(setup):
 
 def test_get_samples_list_two_files():
     sample_dirs = [data_dir / 'SampleA', data_dir / 'SampleB']
-    reader = SnippyVariantsReader(sample_dirs)
+    reader = SnippyVariantsReader.create(sample_dirs)
 
     assert {'SampleA', 'SampleB'} == set(reader.samples_list())
 
 
 def test_read_empty_vcf():
-    reader = SnippyVariantsReader(sample_dirs_empty)
+    reader = SnippyVariantsReader.create(sample_dirs_empty)
     df = reader.get_features_table()
 
     assert 0 == len(df), 'Data has incorrect length'

--- a/storage/test/integration/variant/io/test_SnippyVariantReader.py
+++ b/storage/test/integration/variant/io/test_SnippyVariantReader.py
@@ -57,12 +57,18 @@ def test_read_genomic_masks_from_file(setup):
 
 
 def test_get_genomic_masks(setup):
-    genomic_masks = setup['reader'].get_genomic_masked_regions()
+    variants_reader = setup['reader']
+    mask = variants_reader.get_genomic_masked_region('SampleA')
+    assert 437 == len(mask)
+    assert {'reference'} == mask.sequence_names()
 
-    assert {'SampleA', 'SampleB', 'SampleC'} == set(genomic_masks.keys()), 'Incorrect samples'
-    assert 437 == len(genomic_masks['SampleA'])
-    assert 276 == len(genomic_masks['SampleB'])
-    assert 329 == len(genomic_masks['SampleC'])
+    mask = variants_reader.get_genomic_masked_region('SampleB')
+    assert 276 == len(mask)
+    assert {'reference'} == mask.sequence_names()
+
+    mask = variants_reader.get_genomic_masked_region('SampleC')
+    assert 329 == len(mask)
+    assert {'reference'} == mask.sequence_names()
 
 
 def test_get_samples_list(setup):

--- a/storage/test/integration/variant/io/test_SnippyVariantReader.py
+++ b/storage/test/integration/variant/io/test_SnippyVariantReader.py
@@ -8,6 +8,8 @@ import pytest
 from storage.test.integration.variant import data_dir
 from storage.test.integration.variant import data_dir_empty
 from storage.variant.io.mutation.SnippyVariantsReader import SnippyVariantsReader
+from storage.variant.io.mutation.VcfVariantsReader import VcfVariantsReader
+from storage.variant.io.processor.SerialSampleFilesProcessor import SerialSampleFilesProcessor
 
 sample_dirs = [data_dir / d for d in listdir(data_dir) if path.isdir(data_dir / d)]
 sample_dirs_empty = [data_dir_empty / d for d in listdir(data_dir_empty) if path.isdir(data_dir_empty / d)]
@@ -16,7 +18,8 @@ sample_dirs_empty = [data_dir_empty / d for d in listdir(data_dir_empty) if path
 @pytest.fixture
 def variants_reader() -> SnippyVariantsReader:
     tmp_dir = Path(tempfile.mkdtemp())
-    return SnippyVariantsReader.create(sample_dirs, tmp_dir)
+    return SnippyVariantsReader.create(sample_dirs,
+                                       sample_files_processor=SerialSampleFilesProcessor(tmp_dir))
 
 
 def test_read_vcf(variants_reader):
@@ -80,7 +83,8 @@ def test_get_samples_list_two_files():
 
 def test_read_empty_vcf():
     tmp_dir = Path(tempfile.mkdtemp())
-    reader = SnippyVariantsReader.create(sample_dirs_empty, tmp_dir)
+    reader = SnippyVariantsReader.create(sample_dirs_empty,
+                                         sample_files_processor=SerialSampleFilesProcessor(tmp_dir))
     df = reader.get_features_table()
 
     assert 0 == len(df), 'Data has incorrect length'

--- a/storage/test/integration/variant/io/test_SnippyVariantReader.py
+++ b/storage/test/integration/variant/io/test_SnippyVariantReader.py
@@ -1,6 +1,5 @@
-from os import path, listdir
-from typing import Dict, Any
 import tempfile
+from os import path, listdir
 from pathlib import Path
 
 import pytest
@@ -8,7 +7,6 @@ import pytest
 from storage.test.integration.variant import data_dir
 from storage.test.integration.variant import data_dir_empty
 from storage.variant.io.mutation.SnippyVariantsReader import SnippyVariantsReader
-from storage.variant.io.mutation.VcfVariantsReader import VcfVariantsReader
 from storage.variant.io.processor.SerialSampleFilesProcessor import SerialSampleFilesProcessor
 
 sample_dirs = [data_dir / d for d in listdir(data_dir) if path.isdir(data_dir / d)]

--- a/storage/test/integration/variant/io/test_VariationFile.py
+++ b/storage/test/integration/variant/io/test_VariationFile.py
@@ -1,8 +1,8 @@
 import tempfile
 from pathlib import Path
 
-from storage.test.integration.variant.io import read_vcf_df
 from storage.test.integration.variant import data_dir, regular_vcf_dir, variation_dir, reference_file, consensus_dir
+from storage.test.integration.variant.io import read_vcf_df
 from storage.variant.MaskedGenomicRegions import MaskedGenomicRegions
 from storage.variant.io.mutation.VariationFile import VariationFile
 from storage.variant.util import parse_sequence_file

--- a/storage/test/integration/variant/io/test_VariationFile.py
+++ b/storage/test/integration/variant/io/test_VariationFile.py
@@ -1,21 +1,11 @@
 import tempfile
 from pathlib import Path
 
-import pandas as pd
-import vcf
-
+from storage.test.integration.variant.io import read_vcf_df
 from storage.test.integration.variant import data_dir, regular_vcf_dir, variation_dir, reference_file, consensus_dir
 from storage.variant.MaskedGenomicRegions import MaskedGenomicRegions
 from storage.variant.io.mutation.VariationFile import VariationFile
 from storage.variant.util import parse_sequence_file
-
-
-def read_vcf_df(file: Path) -> pd.DataFrame:
-    reader = vcf.Reader(filename=str(file))
-    df = pd.DataFrame([vars(r) for r in reader])
-    df['TYPE'] = df['INFO'].apply(lambda x: x['TYPE'][0])
-
-    return df
 
 
 def test_write():
@@ -24,8 +14,11 @@ def test_write():
         out_file = Path(out_dir) / 'out.vcf.gz'
 
         assert not out_file.exists()
-        VariationFile(sample_vcf).write(out_file)
+        file, index = VariationFile(sample_vcf).write(out_file)
         assert out_file.exists()
+        assert file == out_file
+        assert index.exists()
+        assert str(file) + '.csi' == str(index)
 
         df = read_vcf_df(out_file)
         assert 'SNP' == df[df['POS'] == 293]['TYPE'].tolist()[0]
@@ -42,8 +35,11 @@ def test_write_2():
         out_file = Path(out_dir) / 'out.vcf.gz'
 
         assert not out_file.exists()
-        VariationFile(sample_vcf).write(out_file)
+        file, index = VariationFile(sample_vcf).write(out_file)
         assert out_file.exists()
+        assert file == out_file
+        assert index.exists()
+        assert str(file) + '.csi' == str(index)
 
         df = read_vcf_df(out_file)
         assert 'INDEL' == df[df['POS'] == 347]['TYPE'].tolist()[0]

--- a/storage/test/integration/variant/io/test_VcfVariantsReader.py
+++ b/storage/test/integration/variant/io/test_VcfVariantsReader.py
@@ -63,13 +63,13 @@ def test_get_variants_table(variants_reader):
     assert 129 == len(df), 'Data has incorrect length'
     assert {'SampleA', 'SampleB', 'SampleC'} == set(df['SAMPLE'].tolist()), 'Incorrect sample names'
 
-    assert ['snp'] == df.loc[(df['SAMPLE'] == 'SampleA') & (df['POS'] == 293), 'TYPE'].tolist()
-    assert ['del'] == df.loc[(df['SAMPLE'] == 'SampleA') & (df['POS'] == 302), 'TYPE'].tolist()
-    assert ['ins'] == df.loc[(df['SAMPLE'] == 'SampleA') & (df['POS'] == 324), 'TYPE'].tolist()
-    assert ['ins'] == df.loc[(df['SAMPLE'] == 'SampleA') & (df['POS'] == 374), 'TYPE'].tolist()
-    assert ['complex'] == df.loc[(df['SAMPLE'] == 'SampleA') & (df['POS'] == 461), 'TYPE'].tolist()
-    assert ['complex'] == df.loc[(df['SAMPLE'] == 'SampleB') & (df['POS'] == 1325), 'TYPE'].tolist()
-    assert ['complex'] == df.loc[(df['SAMPLE'] == 'SampleC') & (df['POS'] == 1984), 'TYPE'].tolist()
+    assert ['SNP'] == df.loc[(df['SAMPLE'] == 'SampleA') & (df['POS'] == 293), 'TYPE'].tolist()
+    assert ['INDEL'] == df.loc[(df['SAMPLE'] == 'SampleA') & (df['POS'] == 302), 'TYPE'].tolist()
+    assert ['INDEL'] == df.loc[(df['SAMPLE'] == 'SampleA') & (df['POS'] == 324), 'TYPE'].tolist()
+    assert ['INDEL'] == df.loc[(df['SAMPLE'] == 'SampleA') & (df['POS'] == 374), 'TYPE'].tolist()
+    assert ['OTHER'] == df.loc[(df['SAMPLE'] == 'SampleA') & (df['POS'] == 461), 'TYPE'].tolist()
+    assert ['OTHER'] == df.loc[(df['SAMPLE'] == 'SampleB') & (df['POS'] == 1325), 'TYPE'].tolist()
+    assert ['OTHER'] == df.loc[(df['SAMPLE'] == 'SampleC') & (df['POS'] == 1984), 'TYPE'].tolist()
 
 
 def test_persist_sample_files(variants_reader: VcfVariantsReader):

--- a/storage/test/integration/variant/io/test_VcfVariantsReader.py
+++ b/storage/test/integration/variant/io/test_VcfVariantsReader.py
@@ -1,6 +1,7 @@
 from os import path, listdir
 from pathlib import Path
 from typing import List
+from tempfile import TemporaryDirectory
 
 import pytest
 
@@ -69,6 +70,22 @@ def test_get_variants_table(variants_reader):
     assert ['complex'] == df.loc[(df['SAMPLE'] == 'SampleA') & (df['POS'] == 461), 'TYPE'].tolist()
     assert ['complex'] == df.loc[(df['SAMPLE'] == 'SampleB') & (df['POS'] == 1325), 'TYPE'].tolist()
     assert ['complex'] == df.loc[(df['SAMPLE'] == 'SampleC') & (df['POS'] == 1984), 'TYPE'].tolist()
+
+
+def test_persist_sample_files(variants_reader: VcfVariantsReader):
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        sample_files = variants_reader.persist_sample_files('SampleA', tmp_dir)
+        vcf_file, vcf_index = sample_files.get_vcf_file()
+        mask_file = sample_files.get_mask_file()
+
+        assert vcf_file.exists()
+        assert vcf_index.exists()
+        assert mask_file.exists()
+
+        assert vcf_file.parent == tmp_dir
+        assert vcf_index.parent == tmp_dir
+        assert mask_file.parent == tmp_dir
 
 
 def test_get_genomic_masks(variants_reader):

--- a/storage/test/integration/variant/io/test_VcfVariantsReader.py
+++ b/storage/test/integration/variant/io/test_VcfVariantsReader.py
@@ -72,22 +72,28 @@ def test_get_variants_table(variants_reader):
 
 
 def test_get_genomic_masks(variants_reader):
-    genomic_masks = variants_reader.get_genomic_masked_regions()
+    mask = variants_reader.get_genomic_masked_region('SampleA')
+    assert 437 == len(mask)
+    assert {'reference'} == mask.sequence_names()
 
-    assert {'SampleA', 'SampleB', 'SampleC'} == set(genomic_masks.keys()), 'Incorrect samples'
-    assert 437 == len(genomic_masks['SampleA'])
-    assert 276 == len(genomic_masks['SampleB'])
-    assert 329 == len(genomic_masks['SampleC'])
+    mask = variants_reader.get_genomic_masked_region('SampleB')
+    assert 276 == len(mask)
+    assert {'reference'} == mask.sequence_names()
 
-    assert {'reference'} == genomic_masks['SampleA'].sequence_names()
-    assert {'reference'} == genomic_masks['SampleB'].sequence_names()
-    assert {'reference'} == genomic_masks['SampleC'].sequence_names()
+    mask = variants_reader.get_genomic_masked_region('SampleC')
+    assert 329 == len(mask)
+    assert {'reference'} == mask.sequence_names()
 
 
 def test_get_genomic_masks_empty(variants_reader_empty_masks):
-    genomic_masks = variants_reader_empty_masks.get_genomic_masked_regions()
-    assert {'SampleA', 'SampleB', 'SampleC'} == set(genomic_masks.keys())
-    assert genomic_masks['SampleA'].is_empty()
+    mask = variants_reader_empty_masks.get_genomic_masked_region('SampleA')
+    assert mask.is_empty()
+
+    mask = variants_reader_empty_masks.get_genomic_masked_region('SampleB')
+    assert mask.is_empty()
+
+    mask = variants_reader_empty_masks.get_genomic_masked_region('SampleC')
+    assert mask.is_empty()
 
 
 def test_get_samples_list(variants_reader):

--- a/storage/test/integration/variant/io/test_VcfVariantsReader.py
+++ b/storage/test/integration/variant/io/test_VcfVariantsReader.py
@@ -1,16 +1,16 @@
+import tempfile
 from os import path, listdir
 from pathlib import Path
-from typing import List, Dict
 from tempfile import TemporaryDirectory
-import tempfile
+from typing import List, Dict
 
 import pytest
 
 from storage.test.integration.variant import data_dir
 from storage.test.integration.variant import data_dir_empty
 from storage.variant.io.mutation.VcfVariantsReader import VcfVariantsReader
-from storage.variant.io.processor.SerialSampleFilesProcessor import SerialSampleFilesProcessor
 from storage.variant.io.processor.MultipleProcessSampleFilesProcessor import MultipleProcessSampleFilesProcessor
+from storage.variant.io.processor.SerialSampleFilesProcessor import SerialSampleFilesProcessor
 
 
 @pytest.fixture
@@ -106,8 +106,9 @@ def test_with_serial_sample_files_processor(sample_dirs):
         tmp_file = Path(tmp_file_str)
         vcf_masks = vcf_and_mask_files(sample_dirs)
         variants_reader = VcfVariantsReader.create_from_sequence_masks(sample_vcf_map=vcf_masks['vcfs'],
-                                                        masked_genomic_files_map=vcf_masks['masks'],
-                                                        sample_files_processor=SerialSampleFilesProcessor(tmp_file))
+                                                                       masked_genomic_files_map=vcf_masks['masks'],
+                                                                       sample_files_processor=SerialSampleFilesProcessor(
+                                                                           tmp_file))
 
         mask = variants_reader.get_genomic_masked_region('SampleA')
         assert 437 == len(mask)
@@ -128,8 +129,8 @@ def test_with_multiprocess_sample_files_processor(sample_dirs):
         vcf_masks = vcf_and_mask_files(sample_dirs)
         file_processor = MultipleProcessSampleFilesProcessor(tmp_file, processing_cores=2)
         variants_reader = VcfVariantsReader.create_from_sequence_masks(sample_vcf_map=vcf_masks['vcfs'],
-                                                        masked_genomic_files_map=vcf_masks['masks'],
-                                                        sample_files_processor=file_processor)
+                                                                       masked_genomic_files_map=vcf_masks['masks'],
+                                                                       sample_files_processor=file_processor)
 
         mask = variants_reader.get_genomic_masked_region('SampleA')
         assert 437 == len(mask)
@@ -147,7 +148,7 @@ def test_with_multiprocess_sample_files_processor(sample_dirs):
 def test_with_null_sample_files_processor(sample_dirs):
     vcf_masks = vcf_and_mask_files(sample_dirs)
     variants_reader = VcfVariantsReader.create_from_sequence_masks(sample_vcf_map=vcf_masks['vcfs'],
-                                                    masked_genomic_files_map=vcf_masks['masks'])
+                                                                   masked_genomic_files_map=vcf_masks['masks'])
 
     with pytest.raises(Exception) as execinfo:
         variants_reader.get_genomic_masked_region('SampleA')

--- a/storage/test/integration/variant/io/test_VcfVariantsReader.py
+++ b/storage/test/integration/variant/io/test_VcfVariantsReader.py
@@ -30,7 +30,7 @@ def variants_reader_internal(sample_dirs):
         sample_vcf_map[sample_name] = vcf_file
         sample_genomic_files_mask[sample_name] = genomic_file_mask
 
-    return VcfVariantsReader(sample_vcf_map=sample_vcf_map,
+    return VcfVariantsReader.create_from_sequence_masks(sample_vcf_map=sample_vcf_map,
                              masked_genomic_files_map=sample_genomic_files_mask)
 
 
@@ -53,7 +53,7 @@ def variants_reader_empty_masks(sample_dirs) -> VcfVariantsReader:
 
         sample_vcf_map[sample_name] = vcf_file
 
-    return VcfVariantsReader(sample_vcf_map=sample_vcf_map)
+    return VcfVariantsReader.create_from_sequence_masks(sample_vcf_map=sample_vcf_map)
 
 
 def test_get_variants_table(variants_reader):

--- a/storage/test/integration/variant/io/test_VcfVariantsReader.py
+++ b/storage/test/integration/variant/io/test_VcfVariantsReader.py
@@ -9,6 +9,7 @@ import pytest
 from storage.test.integration.variant import data_dir
 from storage.test.integration.variant import data_dir_empty
 from storage.variant.io.mutation.VcfVariantsReader import VcfVariantsReader
+from storage.variant.io.processor.SerialSampleFilesProcessor import SerialSampleFilesProcessor
 
 
 @pytest.fixture
@@ -35,7 +36,7 @@ def variants_reader_internal(sample_dirs):
 
     return VcfVariantsReader.create_from_sequence_masks(sample_vcf_map=sample_vcf_map,
                                                         masked_genomic_files_map=sample_genomic_files_mask,
-                                                        preprocess_dir=tmp_dir)
+                                                        sample_files_processor=SerialSampleFilesProcessor(tmp_dir))
 
 
 @pytest.fixture
@@ -59,7 +60,7 @@ def variants_reader_empty_masks(sample_dirs) -> VcfVariantsReader:
         sample_vcf_map[sample_name] = vcf_file
 
     return VcfVariantsReader.create_from_sequence_masks(sample_vcf_map=sample_vcf_map,
-                                                        preprocess_dir=tmp_dir)
+                                                        sample_files_processor=SerialSampleFilesProcessor(tmp_dir))
 
 
 def test_get_variants_table(variants_reader):

--- a/storage/test/integration/variant/service/conftest.py
+++ b/storage/test/integration/variant/service/conftest.py
@@ -43,7 +43,7 @@ def reference_service(database, filesystem_storage) -> ReferenceService:
 
 @pytest.fixture
 def snippy_variants_reader() -> SnippyVariantsReader:
-    return SnippyVariantsReader(sample_dirs)
+    return SnippyVariantsReader.create(sample_dirs)
 
 
 @pytest.fixture
@@ -60,7 +60,7 @@ def regular_variants_reader() -> VcfVariantsReader:
         'SampleC': Path(data_dir, 'SampleC', 'snps.aligned.fa'),
     }
 
-    return VcfVariantsReader(sample_vcf_map=vcf_files, masked_genomic_files_map=mask_files)
+    return VcfVariantsReader.create_from_sequence_masks(sample_vcf_map=vcf_files, masked_genomic_files_map=mask_files)
 
 
 @pytest.fixture

--- a/storage/test/integration/variant/service/test_VariationService.py
+++ b/storage/test/integration/variant/service/test_VariationService.py
@@ -106,8 +106,9 @@ def test_insert_variants_examine_variation(database, snippy_variants_reader, ref
     assert {sample_name_ids['SampleC']} == set(v.sample_ids)
 
 
-def test_insert_variants_regular_vcf_reader_examine_variation(database, regular_variants_reader, reference_service_with_data,
-                                           sample_service, filesystem_storage):
+def test_insert_variants_regular_vcf_reader_examine_variation(database, regular_variants_reader,
+                                                              reference_service_with_data,
+                                                              sample_service, filesystem_storage):
     variation_service = VariationService(database_connection=database,
                                          reference_service=reference_service_with_data,
                                          sample_service=sample_service,

--- a/storage/test/integration/variant/service/test_VariationService.py
+++ b/storage/test/integration/variant/service/test_VariationService.py
@@ -106,7 +106,6 @@ def test_insert_variants_examine_variation(database, snippy_variants_reader, ref
     assert {sample_name_ids['SampleC']} == set(v.sample_ids)
 
 
-@pytest.mark.skip
 def test_insert_variants_regular_vcf_reader_examine_variation(database, regular_variants_reader, reference_service_with_data,
                                            sample_service, filesystem_storage):
     variation_service = VariationService(database_connection=database,

--- a/storage/variant/io/FeaturesReader.py
+++ b/storage/variant/io/FeaturesReader.py
@@ -1,8 +1,10 @@
 import abc
 from pathlib import Path
-from typing import Dict, List, Set
+from typing import Dict, List, Set, Optional
 
 import pandas as pd
+
+from storage.variant.io.SampleFiles import SampleFiles
 
 
 class FeaturesReader(abc.ABC):
@@ -25,6 +27,10 @@ class FeaturesReader(abc.ABC):
         features_df = self._read_features_table()
         self._check_features_table_columns(features_df)
         return features_df
+
+    @abc.abstractmethod
+    def get_sample_files(self, sample_name: str) -> Optional[SampleFiles]:
+        pass
 
     @abc.abstractmethod
     def get_or_create_feature_file(self, sample_name: str):

--- a/storage/variant/io/FeaturesReader.py
+++ b/storage/variant/io/FeaturesReader.py
@@ -27,14 +27,6 @@ class FeaturesReader(abc.ABC):
         return features_df
 
     @abc.abstractmethod
-    def sample_feature_files(self) -> Dict[str, Path]:
-        """
-        Gets a dictionary of sample names to feature files to be read by this reader.
-        :return: A dictionary of sample names to feature files ('name' => 'file')
-        """
-        pass
-
-    @abc.abstractmethod
     def get_or_create_feature_file(self, sample_name: str):
         """
         Gets a file of the features associated with the sample (or creates such a file if it doesn't exist).

--- a/storage/variant/io/FeaturesReader.py
+++ b/storage/variant/io/FeaturesReader.py
@@ -1,6 +1,5 @@
 import abc
-from pathlib import Path
-from typing import Dict, List, Set, Optional
+from typing import List, Set, Optional
 
 import pandas as pd
 

--- a/storage/variant/io/FeaturesReader.py
+++ b/storage/variant/io/FeaturesReader.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 class FeaturesReader(abc.ABC):
 
-    def __init(self):
+    def __init__(self):
         pass
 
     def _check_features_table_columns(self, features_df: pd.DataFrame) -> None:

--- a/storage/variant/io/SampleFiles.py
+++ b/storage/variant/io/SampleFiles.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+import abc
+
+
+class SampleFiles(abc.ABC):
+
+    def __init__(self, sample_name: str):
+        self._name = sample_name
+
+    @property
+    def sample_name(self) -> str:
+        return self._name
+
+    @abc.abstractmethod
+    def is_preprocessed(self) -> bool:
+        pass
+
+    def preprocess(self) -> SampleFiles:
+        if not self.is_preprocessed():
+            return self._do_preprocess()
+        else:
+            return self
+
+    @abc.abstractmethod
+    def _do_preprocess(self) -> SampleFiles:
+        pass

--- a/storage/variant/io/SampleFiles.py
+++ b/storage/variant/io/SampleFiles.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
+
 import abc
-from pathlib import Path
 import logging
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 

--- a/storage/variant/io/SampleFiles.py
+++ b/storage/variant/io/SampleFiles.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 import abc
 from pathlib import Path
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class SampleFiles(abc.ABC):
@@ -18,6 +21,7 @@ class SampleFiles(abc.ABC):
 
     def persist(self, output_dir: Path) -> SampleFiles:
         if not self.is_preprocessed():
+            logger.debug(f'Processing sample [{self.sample_name}] and saving to [{output_dir}]')
             return self._do_preprocess_and_persist(output_dir)
         else:
             return self._do_persist(output_dir)

--- a/storage/variant/io/SampleFiles.py
+++ b/storage/variant/io/SampleFiles.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import abc
+from pathlib import Path
 
 
 class SampleFiles(abc.ABC):
@@ -15,12 +16,12 @@ class SampleFiles(abc.ABC):
     def is_preprocessed(self) -> bool:
         pass
 
-    def preprocess(self) -> SampleFiles:
+    def preprocess(self, output_dir: Path) -> SampleFiles:
         if not self.is_preprocessed():
-            return self._do_preprocess()
+            return self._do_preprocess(output_dir)
         else:
             return self
 
     @abc.abstractmethod
-    def _do_preprocess(self) -> SampleFiles:
+    def _do_preprocess(self, output_dir: Path) -> SampleFiles:
         pass

--- a/storage/variant/io/SampleFiles.py
+++ b/storage/variant/io/SampleFiles.py
@@ -19,6 +19,9 @@ class SampleFiles(abc.ABC):
     def is_preprocessed(self) -> bool:
         pass
 
+    def preprocess(self, output_dir: Path) -> SampleFiles:
+        return self.persist(output_dir)
+
     def persist(self, output_dir: Path) -> SampleFiles:
         if not self.is_preprocessed():
             logger.debug(f'Processing sample [{self.sample_name}] and saving to [{output_dir}]')

--- a/storage/variant/io/SampleFiles.py
+++ b/storage/variant/io/SampleFiles.py
@@ -16,12 +16,16 @@ class SampleFiles(abc.ABC):
     def is_preprocessed(self) -> bool:
         pass
 
-    def preprocess(self, output_dir: Path) -> SampleFiles:
+    def persist(self, output_dir: Path) -> SampleFiles:
         if not self.is_preprocessed():
-            return self._do_preprocess(output_dir)
+            return self._do_preprocess_and_persist(output_dir)
         else:
-            return self
+            return self._do_persist(output_dir)
 
     @abc.abstractmethod
-    def _do_preprocess(self, output_dir: Path) -> SampleFiles:
+    def _do_preprocess_and_persist(self, output_dir: Path) -> SampleFiles:
+        pass
+
+    @abc.abstractmethod
+    def _do_persist(self, output_dir: Path) -> SampleFiles:
         pass

--- a/storage/variant/io/SampleFilesProcessor.py
+++ b/storage/variant/io/SampleFilesProcessor.py
@@ -1,0 +1,13 @@
+import abc
+
+from storage.variant.io.FeaturesReader import FeaturesReader
+
+
+class SampleFilesProcessor(abc.ABC):
+
+    def __init__(self):
+        pass
+
+    @abc.abstractmethod
+    def preprocess_files(self, reader: FeaturesReader) -> FeaturesReader:
+        pass

--- a/storage/variant/io/SampleFilesProcessor.py
+++ b/storage/variant/io/SampleFilesProcessor.py
@@ -1,13 +1,20 @@
 import abc
+from typing import Dict, List
 
-from storage.variant.io.FeaturesReader import FeaturesReader
+from storage.variant.io.SampleFiles import SampleFiles
 
 
 class SampleFilesProcessor(abc.ABC):
 
     def __init__(self):
-        pass
+        self._sample_files_list = []
+
+    def add(self, sample_files: SampleFiles) -> None:
+        self._sample_files_list.append(sample_files)
+
+    def sample_files_list(self) -> List[SampleFiles]:
+        return self._sample_files_list
 
     @abc.abstractmethod
-    def preprocess_files(self, reader: FeaturesReader) -> FeaturesReader:
+    def preprocess_files(self) -> Dict[str, SampleFiles]:
         pass

--- a/storage/variant/io/mlst/MLSTFeaturesReader.py
+++ b/storage/variant/io/mlst/MLSTFeaturesReader.py
@@ -1,11 +1,10 @@
 import abc
-from pathlib import Path
-from typing import Set, List, Dict
+from typing import Set, List
 
 import pandas as pd
 
-from storage.variant.io.SampleFiles import SampleFiles
 from storage.variant.io.FeaturesReader import FeaturesReader
+from storage.variant.io.SampleFiles import SampleFiles
 from storage.variant.model import MLST_UNKNOWN_ALLELE
 
 

--- a/storage/variant/io/mlst/MLSTFeaturesReader.py
+++ b/storage/variant/io/mlst/MLSTFeaturesReader.py
@@ -4,6 +4,7 @@ from typing import Set, List, Dict
 
 import pandas as pd
 
+from storage.variant.io.SampleFiles import SampleFiles
 from storage.variant.io.FeaturesReader import FeaturesReader
 from storage.variant.model import MLST_UNKNOWN_ALLELE
 
@@ -13,6 +14,9 @@ class MLSTFeaturesReader(FeaturesReader):
     def __init__(self):
         super().__init__()
         self._features_table = None
+
+    def get_sample_files(self, sample_name: str) -> SampleFiles:
+        return None
 
     def get_features_table(self) -> pd.DataFrame:
         if self._features_table is None:

--- a/storage/variant/io/mlst/MLSTFeaturesReader.py
+++ b/storage/variant/io/mlst/MLSTFeaturesReader.py
@@ -36,9 +36,6 @@ class MLSTFeaturesReader(FeaturesReader):
         mlst_df = self.get_features_table()
         return list(set(mlst_df['Sample'].tolist()))
 
-    def sample_feature_files(self) -> Dict[str, Path]:
-        raise Exception('Not implemented')
-
     def get_or_create_feature_file(self, sample_name: str):
         raise Exception('Not implemented')
 

--- a/storage/variant/io/mutation/NucleotideFeaturesReader.py
+++ b/storage/variant/io/mutation/NucleotideFeaturesReader.py
@@ -1,10 +1,8 @@
 import abc
 from typing import Set
-from pathlib import Path
 
 from storage.variant.MaskedGenomicRegions import MaskedGenomicRegions
 from storage.variant.io.FeaturesReader import FeaturesReader
-from storage.variant.io.mutation.NucleotideSampleFiles import NucleotideSampleFiles
 
 
 class NucleotideFeaturesReader(FeaturesReader):

--- a/storage/variant/io/mutation/NucleotideFeaturesReader.py
+++ b/storage/variant/io/mutation/NucleotideFeaturesReader.py
@@ -16,9 +16,5 @@ class NucleotideFeaturesReader(FeaturesReader):
         return {'SAMPLE', 'CHROM', 'POS', 'REF', 'ALT', 'TYPE'}
 
     @abc.abstractmethod
-    def persist_sample_files(self, sample_name: str, persistence_dir: Path) -> NucleotideSampleFiles:
-        pass
-
-    @abc.abstractmethod
     def get_genomic_masked_region(self, sample_name: str) -> MaskedGenomicRegions:
         pass

--- a/storage/variant/io/mutation/NucleotideFeaturesReader.py
+++ b/storage/variant/io/mutation/NucleotideFeaturesReader.py
@@ -9,16 +9,10 @@ class NucleotideFeaturesReader(FeaturesReader):
 
     def __init__(self):
         super().__init__()
-        self._genomic_masked_regions: Optional[Dict[str, MaskedGenomicRegions]] = None
 
     def _minimal_expected_columns(self) -> Set[str]:
         return {'SAMPLE', 'CHROM', 'POS', 'REF', 'ALT', 'TYPE'}
 
-    def get_genomic_masked_regions(self) -> Dict[str, MaskedGenomicRegions]:
-        if self._genomic_masked_regions is None:
-            self._genomic_masked_regions = self._read_genomic_masked_regions()
-        return self._genomic_masked_regions
-
     @abc.abstractmethod
-    def _read_genomic_masked_regions(self) -> Dict[str, MaskedGenomicRegions]:
+    def get_genomic_masked_region(self, sample_name: str) -> MaskedGenomicRegions:
         pass

--- a/storage/variant/io/mutation/NucleotideFeaturesReader.py
+++ b/storage/variant/io/mutation/NucleotideFeaturesReader.py
@@ -1,8 +1,10 @@
 import abc
-from typing import Dict, Set, Optional
+from typing import Set
+from pathlib import Path
 
 from storage.variant.MaskedGenomicRegions import MaskedGenomicRegions
 from storage.variant.io.FeaturesReader import FeaturesReader
+from storage.variant.io.mutation.NucleotideSampleFiles import NucleotideSampleFiles
 
 
 class NucleotideFeaturesReader(FeaturesReader):
@@ -12,6 +14,10 @@ class NucleotideFeaturesReader(FeaturesReader):
 
     def _minimal_expected_columns(self) -> Set[str]:
         return {'SAMPLE', 'CHROM', 'POS', 'REF', 'ALT', 'TYPE'}
+
+    @abc.abstractmethod
+    def persist_sample_files(self, sample_name: str, persistence_dir: Path) -> NucleotideSampleFiles:
+        pass
 
     @abc.abstractmethod
     def get_genomic_masked_region(self, sample_name: str) -> MaskedGenomicRegions:

--- a/storage/variant/io/mutation/NucleotideSampleFiles.py
+++ b/storage/variant/io/mutation/NucleotideSampleFiles.py
@@ -1,21 +1,41 @@
 from abc import ABC
-from typing import Tuple
+from typing import Tuple, Optional
 from pathlib import Path
-import os
 
 from storage.variant.io.SampleFiles import SampleFiles
+from storage.variant.MaskedGenomicRegions import MaskedGenomicRegions
 from storage.variant.io.mutation.VariationFile import VariationFile
 
 
-class NucleotideSampleFiles(SampleFiles, ABC):
+class NucleotideSampleFiles(SampleFiles):
 
-    def __init__(self, sample_name: str, vcf_file: Path, vcf_file_index: Path, preprocessed: bool,
+    def __init__(self, sample_name: str, vcf_file: Path, vcf_file_index: Path,
+                 mask_bed_file: Optional[Path],
+                 preprocessed: bool,
                  tmp_dir: Path):
         super().__init__(sample_name=sample_name)
         self._vcf_file = vcf_file
         self._vcf_file_index = vcf_file_index
         self._tmp_dir = tmp_dir
         self._preprocessed = preprocessed
+        self._mask_bed_file = mask_bed_file
+
+    def _preprocess_mask(self) -> Path:
+        if self._mask_bed_file is None:
+            raise Exception('mask_bed_file does not exist')
+        else:
+            return self._mask_bed_file
+
+    def _do_preprocess(self) -> SampleFiles:
+        processed_vcf, processed_vcf_index = self._preprocess_vcf()
+        processed_mask = self._preprocess_mask()
+
+        return NucleotideSampleFiles(sample_name=self.sample_name,
+                                     vcf_file=processed_vcf,
+                                     vcf_file_index=processed_vcf_index,
+                                     mask_bed_file=processed_mask,
+                                     preprocessed=True,
+                                     tmp_dir=self._tmp_dir)
 
     def is_preprocessed(self) -> bool:
         return self._preprocessed
@@ -29,3 +49,9 @@ class NucleotideSampleFiles(SampleFiles, ABC):
             return self._vcf_file, self._vcf_file_index
         else:
             raise Exception(f'VCF file for sample [{self.sample_name}] is not preprocessed: {self._vcf_file}')
+
+    def get_mask(self) -> MaskedGenomicRegions:
+        if self._preprocessed and self._mask_bed_file is not None:
+            return MaskedGenomicRegions.from_file(self._mask_bed_file)
+        else:
+            raise Exception(f'Sample mask file is not preprocessed for sample [{self.sample_name}]')

--- a/storage/variant/io/mutation/NucleotideSampleFiles.py
+++ b/storage/variant/io/mutation/NucleotideSampleFiles.py
@@ -1,0 +1,31 @@
+from abc import ABC
+from typing import Tuple
+from pathlib import Path
+import os
+
+from storage.variant.io.SampleFiles import SampleFiles
+from storage.variant.io.mutation.VariationFile import VariationFile
+
+
+class NucleotideSampleFiles(SampleFiles, ABC):
+
+    def __init__(self, sample_name: str, vcf_file: Path, vcf_file_index: Path, preprocessed: bool,
+                 tmp_dir: Path):
+        super().__init__(sample_name=sample_name)
+        self._vcf_file = vcf_file
+        self._vcf_file_index = vcf_file_index
+        self._tmp_dir = tmp_dir
+        self._preprocessed = preprocessed
+
+    def is_preprocessed(self) -> bool:
+        return self._preprocessed
+
+    def _preprocess_vcf(self) -> Tuple[Path, Path]:
+        new_file = self._tmp_dir / f'{self.sample_name}.vcf.gz'
+        return VariationFile(self._vcf_file).write(new_file)
+
+    def get_vcf_file(self, ignore_preprocessed = False) -> Tuple[Path, Path]:
+        if ignore_preprocessed or self._preprocessed:
+            return self._vcf_file, self._vcf_file_index
+        else:
+            raise Exception(f'VCF file for sample [{self.sample_name}] is not preprocessed: {self._vcf_file}')

--- a/storage/variant/io/mutation/NucleotideSampleFiles.py
+++ b/storage/variant/io/mutation/NucleotideSampleFiles.py
@@ -1,10 +1,10 @@
-from typing import Tuple, Optional
-from pathlib import Path
-import shutil
 import logging
+import shutil
+from pathlib import Path
+from typing import Tuple, Optional
 
-from storage.variant.io.SampleFiles import SampleFiles
 from storage.variant.MaskedGenomicRegions import MaskedGenomicRegions
+from storage.variant.io.SampleFiles import SampleFiles
 from storage.variant.io.mutation.VariationFile import VariationFile
 
 logger = logging.getLogger(__name__)

--- a/storage/variant/io/mutation/NucleotideSampleFiles.py
+++ b/storage/variant/io/mutation/NucleotideSampleFiles.py
@@ -11,37 +11,34 @@ class NucleotideSampleFiles(SampleFiles):
 
     def __init__(self, sample_name: str, vcf_file: Path, vcf_file_index: Path,
                  mask_bed_file: Optional[Path],
-                 preprocessed: bool,
-                 tmp_dir: Path):
+                 preprocessed: bool):
         super().__init__(sample_name=sample_name)
         self._vcf_file = vcf_file
         self._vcf_file_index = vcf_file_index
-        self._tmp_dir = tmp_dir
         self._preprocessed = preprocessed
         self._mask_bed_file = mask_bed_file
 
-    def _preprocess_mask(self) -> Path:
+    def _preprocess_mask(self, output_dir: Path) -> Path:
         if self._mask_bed_file is None:
             raise Exception('mask_bed_file does not exist')
         else:
             return self._mask_bed_file
 
-    def _do_preprocess(self) -> SampleFiles:
-        processed_vcf, processed_vcf_index = self._preprocess_vcf()
-        processed_mask = self._preprocess_mask()
+    def _do_preprocess(self, output_dir: Path) -> SampleFiles:
+        processed_vcf, processed_vcf_index = self._preprocess_vcf(output_dir)
+        processed_mask = self._preprocess_mask(output_dir)
 
         return NucleotideSampleFiles(sample_name=self.sample_name,
                                      vcf_file=processed_vcf,
                                      vcf_file_index=processed_vcf_index,
                                      mask_bed_file=processed_mask,
-                                     preprocessed=True,
-                                     tmp_dir=self._tmp_dir)
+                                     preprocessed=True)
 
     def is_preprocessed(self) -> bool:
         return self._preprocessed
 
-    def _preprocess_vcf(self) -> Tuple[Path, Path]:
-        new_file = self._tmp_dir / f'{self.sample_name}.vcf.gz'
+    def _preprocess_vcf(self, output_dir: Path) -> Tuple[Path, Path]:
+        new_file = output_dir / f'{self.sample_name}.vcf.gz'
         return VariationFile(self._vcf_file).write(new_file)
 
     def get_vcf_file(self, ignore_preprocessed = False) -> Tuple[Path, Path]:

--- a/storage/variant/io/mutation/NucleotideSampleFiles.py
+++ b/storage/variant/io/mutation/NucleotideSampleFiles.py
@@ -23,9 +23,11 @@ class NucleotideSampleFiles(SampleFiles):
 
     def _preprocess_mask(self, output_dir: Path) -> Path:
         if self._mask_bed_file is None:
-            raise Exception('mask_bed_file does not exist')
-        else:
-            return self._mask_bed_file
+            mask_file = output_dir / f'{self.sample_name}.bed.gz'
+            mask = MaskedGenomicRegions.empty_mask()
+            mask.write(mask_file)
+            self._mask_bed_file = mask_file
+        return self._mask_bed_file
 
     def _do_preprocess_and_persist(self, output_dir: Path) -> SampleFiles:
         processed_vcf, processed_vcf_index = self._preprocess_vcf(output_dir)
@@ -38,6 +40,9 @@ class NucleotideSampleFiles(SampleFiles):
                                      preprocessed=True)
 
     def _do_persist(self, output_dir: Path) -> SampleFiles:
+        if self._mask_bed_file is None:
+            raise Exception('mask_bed_file is None')
+
         new_vcf_file = output_dir / self._vcf_file.name
         new_vcf_index = output_dir / self._vcf_file_index.name
         new_mask_bed_file = output_dir / self._mask_bed_file.name

--- a/storage/variant/io/mutation/NucleotideSampleFiles.py
+++ b/storage/variant/io/mutation/NucleotideSampleFiles.py
@@ -24,10 +24,16 @@ class NucleotideSampleFiles(SampleFiles):
     def _preprocess_mask(self, output_dir: Path) -> Path:
         if self._mask_bed_file is None:
             mask_file = output_dir / f'{self.sample_name}.bed.gz'
+            self._assert_file_not_exists(mask_file, 'Cannot preprocess data')
             mask = MaskedGenomicRegions.empty_mask()
             mask.write(mask_file)
             self._mask_bed_file = mask_file
         return self._mask_bed_file
+
+    def _preprocess_vcf(self, output_dir: Path) -> Tuple[Path, Path]:
+        new_file = output_dir / f'{self.sample_name}.vcf.gz'
+        self._assert_file_not_exists(new_file, 'Cannot preprocess data')
+        return VariationFile(self._vcf_file).write(new_file)
 
     def _do_preprocess_and_persist(self, output_dir: Path) -> SampleFiles:
         processed_vcf, processed_vcf_index = self._preprocess_vcf(output_dir)
@@ -47,6 +53,10 @@ class NucleotideSampleFiles(SampleFiles):
         new_vcf_index = output_dir / self._vcf_file_index.name
         new_mask_bed_file = output_dir / self._mask_bed_file.name
 
+        self._assert_file_not_exists(new_vcf_file, 'Cannot persist data')
+        self._assert_file_not_exists(new_vcf_index, 'Cannot persist data')
+        self._assert_file_not_exists(new_mask_bed_file, 'Cannot persist data')
+
         logger.debug(f'Copying VCF and BED files to [{output_dir}] for sample [{self.sample_name}]')
 
         shutil.copy(self._vcf_file, new_vcf_file)
@@ -62,9 +72,9 @@ class NucleotideSampleFiles(SampleFiles):
     def is_preprocessed(self) -> bool:
         return self._preprocessed
 
-    def _preprocess_vcf(self, output_dir: Path) -> Tuple[Path, Path]:
-        new_file = output_dir / f'{self.sample_name}.vcf.gz'
-        return VariationFile(self._vcf_file).write(new_file)
+    def _assert_file_not_exists(self, file: Path, error_prefix: str):
+        if file.exists():
+            raise Exception(f'{error_prefix} for sample [{self.sample_name}]: file [{file}] exists')
 
     def get_vcf_file(self, ignore_preprocessed=False) -> Tuple[Path, Path]:
         if ignore_preprocessed or self._preprocessed:

--- a/storage/variant/io/mutation/NucleotideSampleFilesSequenceMask.py
+++ b/storage/variant/io/mutation/NucleotideSampleFilesSequenceMask.py
@@ -11,7 +11,8 @@ logger = logging.getLogger(__name__)
 
 class NucleotideSampleFilesSequenceMask(NucleotideSampleFiles):
 
-    def __init__(self, sample_name: str, vcf_file: Path, vcf_file_index: Optional[Path], sample_mask_sequence: Path):
+    def __init__(self, sample_name: str, vcf_file: Path, vcf_file_index: Optional[Path],
+                 sample_mask_sequence: Optional[Path]):
         super().__init__(sample_name=sample_name,
                          vcf_file=vcf_file,
                          vcf_file_index=vcf_file_index,
@@ -20,18 +21,25 @@ class NucleotideSampleFilesSequenceMask(NucleotideSampleFiles):
         self._sample_mask_sequence = sample_mask_sequence
 
     def _preprocess_mask(self, output_dir: Path) -> Path:
-        new_file = output_dir / f'{self.sample_name}.bed.gz'
-        if new_file.exists():
-            raise Exception(f'File {new_file} already exists')
+        if self._sample_mask_sequence is None:
+            mask_file = output_dir / f'{self.sample_name}.bed.gz'
+            mask = MaskedGenomicRegions.empty_mask()
+            mask.write(mask_file)
+            return mask_file
+        else:
+            new_file = output_dir / f'{self.sample_name}.bed.gz'
+            if new_file.exists():
+                raise Exception(f'File {new_file} already exists')
 
-        name, records = parse_sequence_file(self._sample_mask_sequence)
-        logger.debug(f'Getting genomic masks from {self._sample_mask_sequence}')
-        masked_regions = MaskedGenomicRegions.from_sequences(sequences=records)
-        masked_regions.write(new_file)
-        return new_file
+            name, records = parse_sequence_file(self._sample_mask_sequence)
+            logger.debug(f'Getting genomic masks from {self._sample_mask_sequence}')
+            masked_regions = MaskedGenomicRegions.from_sequences(sequences=records)
+            masked_regions.write(new_file)
+            return new_file
 
     @classmethod
-    def create(cls, sample_name: str, vcf_file: Path, sample_mask_sequence: Path) -> NucleotideSampleFiles:
+    def create(cls, sample_name: str, vcf_file: Path,
+               sample_mask_sequence: Optional[Path] = None) -> NucleotideSampleFiles:
         return NucleotideSampleFilesSequenceMask(sample_name=sample_name,
                                                  vcf_file=vcf_file,
                                                  vcf_file_index=None,

--- a/storage/variant/io/mutation/NucleotideSampleFilesSequenceMask.py
+++ b/storage/variant/io/mutation/NucleotideSampleFilesSequenceMask.py
@@ -11,18 +11,16 @@ logger = logging.getLogger(__name__)
 
 class NucleotideSampleFilesSequenceMask(NucleotideSampleFiles):
 
-    def __init__(self, sample_name: str, vcf_file: Path, vcf_file_index: Optional[Path], sample_mask_sequence: Path,
-                 tmp_dir: Path):
+    def __init__(self, sample_name: str, vcf_file: Path, vcf_file_index: Optional[Path], sample_mask_sequence: Path):
         super().__init__(sample_name=sample_name,
                          vcf_file=vcf_file,
                          vcf_file_index=vcf_file_index,
                          mask_bed_file=None,
-                         preprocessed=False,
-                         tmp_dir=tmp_dir)
+                         preprocessed=False)
         self._sample_mask_sequence = sample_mask_sequence
 
-    def _preprocess_mask(self) -> Path:
-        new_file = self._tmp_dir / f'{self.sample_name}.bed.gz'
+    def _preprocess_mask(self, output_dir: Path) -> Path:
+        new_file = output_dir / f'{self.sample_name}.bed.gz'
         if new_file.exists():
             raise Exception(f'File {new_file} already exists')
 
@@ -33,10 +31,8 @@ class NucleotideSampleFilesSequenceMask(NucleotideSampleFiles):
         return new_file
 
     @classmethod
-    def create(cls, sample_name: str, vcf_file: Path, sample_mask_sequence: Path,
-               tmp_dir: Path) -> NucleotideSampleFiles:
+    def create(cls, sample_name: str, vcf_file: Path, sample_mask_sequence: Path) -> NucleotideSampleFiles:
         return NucleotideSampleFilesSequenceMask(sample_name=sample_name,
                                                  vcf_file=vcf_file,
                                                  vcf_file_index=None,
-                                                 sample_mask_sequence=sample_mask_sequence,
-                                                 tmp_dir=tmp_dir)
+                                                 sample_mask_sequence=sample_mask_sequence)

--- a/storage/variant/io/mutation/NucleotideSampleFilesSequenceMask.py
+++ b/storage/variant/io/mutation/NucleotideSampleFilesSequenceMask.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import Optional
 import logging
 
-from storage.variant.io.SampleFiles import SampleFiles
 from storage.variant.io.mutation.NucleotideSampleFiles import NucleotideSampleFiles
 from storage.variant.MaskedGenomicRegions import MaskedGenomicRegions
 from storage.variant.util import parse_sequence_file
@@ -12,40 +11,32 @@ logger = logging.getLogger(__name__)
 
 class NucleotideSampleFilesSequenceMask(NucleotideSampleFiles):
 
-    def __init__(self, sample_name: str, vcf_file: Path, vcf_file_index: Optional[Path], sample_mask: Path, tmp_dir: Path,
-                 preprocessed: bool = False):
-        super().__init__(sample_name=sample_name, vcf_file=vcf_file, vcf_file_index=vcf_file_index,
-                         preprocessed=preprocessed,
+    def __init__(self, sample_name: str, vcf_file: Path, vcf_file_index: Optional[Path], sample_mask_sequence: Path,
+                 tmp_dir: Path):
+        super().__init__(sample_name=sample_name,
+                         vcf_file=vcf_file,
+                         vcf_file_index=vcf_file_index,
+                         mask_bed_file=None,
+                         preprocessed=False,
                          tmp_dir=tmp_dir)
-        self._sample_mask = sample_mask
+        self._sample_mask_sequence = sample_mask_sequence
 
     def _preprocess_mask(self) -> Path:
         new_file = self._tmp_dir / f'{self.sample_name}.bed.gz'
         if new_file.exists():
             raise Exception(f'File {new_file} already exists')
 
-        name, records = parse_sequence_file(self._sample_mask)
-        logger.debug(f'Getting genomic masks from {self._sample_mask}')
+        name, records = parse_sequence_file(self._sample_mask_sequence)
+        logger.debug(f'Getting genomic masks from {self._sample_mask_sequence}')
         masked_regions = MaskedGenomicRegions.from_sequences(sequences=records)
         masked_regions.write(new_file)
         return new_file
 
-    def _do_preprocess(self) -> SampleFiles:
-        processed_vcf, processed_vcf_index = self._preprocess_vcf()
-        processed_mask = self._preprocess_mask()
-
-        return NucleotideSampleFilesSequenceMask(sample_name=self.sample_name,
-                                                 vcf_file=processed_vcf,
-                                                 vcf_file_index=processed_vcf_index,
-                                                 sample_mask=processed_mask,
-                                                 preprocessed=True,
-                                                 tmp_dir=self._tmp_dir)
-
     @classmethod
-    def create(cls, sample_name: str, vcf_file: Path, sample_mask: Path, tmp_dir: Path) -> NucleotideSampleFiles:
+    def create(cls, sample_name: str, vcf_file: Path, sample_mask_sequence: Path,
+               tmp_dir: Path) -> NucleotideSampleFiles:
         return NucleotideSampleFilesSequenceMask(sample_name=sample_name,
                                                  vcf_file=vcf_file,
                                                  vcf_file_index=None,
-                                                 sample_mask=sample_mask,
-                                                 preprocessed=False,
+                                                 sample_mask_sequence=sample_mask_sequence,
                                                  tmp_dir=tmp_dir)

--- a/storage/variant/io/mutation/NucleotideSampleFilesSequenceMask.py
+++ b/storage/variant/io/mutation/NucleotideSampleFilesSequenceMask.py
@@ -1,9 +1,9 @@
+import logging
 from pathlib import Path
 from typing import Optional
-import logging
 
-from storage.variant.io.mutation.NucleotideSampleFiles import NucleotideSampleFiles
 from storage.variant.MaskedGenomicRegions import MaskedGenomicRegions
+from storage.variant.io.mutation.NucleotideSampleFiles import NucleotideSampleFiles
 from storage.variant.util import parse_sequence_file
 
 logger = logging.getLogger(__name__)

--- a/storage/variant/io/mutation/NucleotideSampleFilesSequenceMask.py
+++ b/storage/variant/io/mutation/NucleotideSampleFilesSequenceMask.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from typing import Optional
+import logging
+
+from storage.variant.io.SampleFiles import SampleFiles
+from storage.variant.io.mutation.NucleotideSampleFiles import NucleotideSampleFiles
+from storage.variant.MaskedGenomicRegions import MaskedGenomicRegions
+from storage.variant.util import parse_sequence_file
+
+logger = logging.getLogger(__name__)
+
+
+class NucleotideSampleFilesSequenceMask(NucleotideSampleFiles):
+
+    def __init__(self, sample_name: str, vcf_file: Path, vcf_file_index: Optional[Path], sample_mask: Path, tmp_dir: Path,
+                 preprocessed: bool = False):
+        super().__init__(sample_name=sample_name, vcf_file=vcf_file, vcf_file_index=vcf_file_index,
+                         preprocessed=preprocessed,
+                         tmp_dir=tmp_dir)
+        self._sample_mask = sample_mask
+
+    def _preprocess_mask(self) -> Path:
+        new_file = self._tmp_dir / f'{self.sample_name}.bed.gz'
+        if new_file.exists():
+            raise Exception(f'File {new_file} already exists')
+
+        name, records = parse_sequence_file(self._sample_mask)
+        logger.debug(f'Getting genomic masks from {self._sample_mask}')
+        masked_regions = MaskedGenomicRegions.from_sequences(sequences=records)
+        masked_regions.write(new_file)
+        return new_file
+
+    def _do_preprocess(self) -> SampleFiles:
+        processed_vcf, processed_vcf_index = self._preprocess_vcf()
+        processed_mask = self._preprocess_mask()
+
+        return NucleotideSampleFilesSequenceMask(sample_name=self.sample_name,
+                                                 vcf_file=processed_vcf,
+                                                 vcf_file_index=processed_vcf_index,
+                                                 sample_mask=processed_mask,
+                                                 preprocessed=True,
+                                                 tmp_dir=self._tmp_dir)
+
+    @classmethod
+    def create(cls, sample_name: str, vcf_file: Path, sample_mask: Path, tmp_dir: Path) -> NucleotideSampleFiles:
+        return NucleotideSampleFilesSequenceMask(sample_name=sample_name,
+                                                 vcf_file=vcf_file,
+                                                 vcf_file_index=None,
+                                                 sample_mask=sample_mask,
+                                                 preprocessed=False,
+                                                 tmp_dir=tmp_dir)

--- a/storage/variant/io/mutation/SnippyVariantsReader.py
+++ b/storage/variant/io/mutation/SnippyVariantsReader.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
+
 import logging
-import os
 from pathlib import Path
 from typing import List, Dict
-import tempfile
 
 import pandas as pd
 
-from storage.variant.io.mutation.VcfVariantsReader import VcfVariantsReader
-from storage.variant.io.mutation.NucleotideSampleFilesSequenceMask import NucleotideSampleFilesSequenceMask
-from storage.variant.io.mutation.NucleotideSampleFiles import NucleotideSampleFiles
-from storage.variant.io.processor.NullSampleFilesProcessor import NullSampleFilesProcessor
 from storage.variant.io.SampleFilesProcessor import SampleFilesProcessor
+from storage.variant.io.mutation.NucleotideSampleFiles import NucleotideSampleFiles
+from storage.variant.io.mutation.NucleotideSampleFilesSequenceMask import NucleotideSampleFilesSequenceMask
+from storage.variant.io.mutation.VcfVariantsReader import VcfVariantsReader
+from storage.variant.io.processor.NullSampleFilesProcessor import NullSampleFilesProcessor
 
 logger = logging.getLogger(__name__)
 

--- a/storage/variant/io/mutation/SnippyVariantsReader.py
+++ b/storage/variant/io/mutation/SnippyVariantsReader.py
@@ -1,28 +1,22 @@
 import logging
 import os
 from pathlib import Path
-from typing import List
+from typing import List, Dict
+import tempfile
 
 import pandas as pd
 
 from storage.variant.io.mutation.VcfVariantsReader import VcfVariantsReader
+from storage.variant.io.mutation.NucleotideSampleFilesSequenceMask import NucleotideSampleFilesSequenceMask
+from storage.variant.io.mutation.NucleotideSampleFiles import NucleotideSampleFiles
 
 logger = logging.getLogger(__name__)
 
 
 class SnippyVariantsReader(VcfVariantsReader):
 
-    def __init__(self, sample_dirs: List[Path]):
-        self._sample_dirs = sample_dirs
-
-        vcf_map = {}
-        masked_genomic_files_map = {}
-        for d in self._sample_dirs:
-            sample_name = os.path.basename(d)
-            vcf_map[sample_name] = Path(d, 'snps.vcf.gz')
-            masked_genomic_files_map[sample_name] = Path(d, 'snps.aligned.fa')
-
-        super().__init__(sample_vcf_map=vcf_map, masked_genomic_files_map=masked_genomic_files_map)
+    def __init__(self, sample_files_map: Dict[str, NucleotideSampleFiles]):
+        super().__init__(sample_files_map=sample_files_map)
 
     def _get_type(self, vcf_df: pd.DataFrame) -> pd.Series:
         return vcf_df['INFO'].map(lambda x: x['TYPE'][0])
@@ -38,3 +32,19 @@ class SnippyVariantsReader(VcfVariantsReader):
 
     def _drop_extra_columns(self, vcf_df: pd.DataFrame) -> pd.DataFrame:
         return vcf_df.drop('INFO', axis='columns')
+
+
+    @classmethod
+    def create(cls, sample_dirs: List[Path]):
+        sample_files_map = {}
+        tmp_dir = Path(tempfile.mkdtemp())
+
+        for d in sample_dirs:
+            sample_name = d.name
+            sample_files_map[sample_name] = NucleotideSampleFilesSequenceMask.create(
+                sample_name=sample_name,
+                vcf_file=Path(d, 'snps.vcf.gz'),
+                sample_mask_sequence=Path(d, 'snps.aligned.fa')
+            ).persist(tmp_dir)
+
+        return SnippyVariantsReader(sample_files_map=sample_files_map)

--- a/storage/variant/io/mutation/SnippyVariantsReader.py
+++ b/storage/variant/io/mutation/SnippyVariantsReader.py
@@ -18,9 +18,6 @@ class SnippyVariantsReader(VcfVariantsReader):
     def __init__(self, sample_files_map: Dict[str, NucleotideSampleFiles]):
         super().__init__(sample_files_map=sample_files_map)
 
-    def _get_type(self, vcf_df: pd.DataFrame) -> pd.Series:
-        return vcf_df['INFO'].map(lambda x: x['TYPE'][0])
-
     def _fix_df_columns(self, vcf_df: pd.DataFrame) -> pd.DataFrame:
         # If no data, I still want certain column names so that rest of code still works
         if len(vcf_df) == 0:
@@ -29,10 +26,6 @@ class SnippyVariantsReader(VcfVariantsReader):
         out = vcf_df.merge(pd.DataFrame(vcf_df.INFO.tolist()),
                            left_index=True, right_index=True)
         return out[['CHROM', 'POS', 'REF', 'ALT', 'INFO']]
-
-    def _drop_extra_columns(self, vcf_df: pd.DataFrame) -> pd.DataFrame:
-        return vcf_df.drop('INFO', axis='columns')
-
 
     @classmethod
     def create(cls, sample_dirs: List[Path]):

--- a/storage/variant/io/mutation/SnippyVariantsReader.py
+++ b/storage/variant/io/mutation/SnippyVariantsReader.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import logging
 import os
 from pathlib import Path
@@ -28,16 +29,20 @@ class SnippyVariantsReader(VcfVariantsReader):
         return out[['CHROM', 'POS', 'REF', 'ALT', 'INFO']]
 
     @classmethod
-    def create(cls, sample_dirs: List[Path]):
+    def create(cls, sample_dirs: List[Path], preprocess_dir: Path = None) -> SnippyVariantsReader:
         sample_files_map = {}
-        tmp_dir = Path(tempfile.mkdtemp())
 
         for d in sample_dirs:
             sample_name = d.name
-            sample_files_map[sample_name] = NucleotideSampleFilesSequenceMask.create(
+            sample_files = NucleotideSampleFilesSequenceMask.create(
                 sample_name=sample_name,
                 vcf_file=Path(d, 'snps.vcf.gz'),
                 sample_mask_sequence=Path(d, 'snps.aligned.fa')
-            ).persist(tmp_dir)
+            )
+
+            if preprocess_dir is not None:
+                sample_files = sample_files.persist(preprocess_dir)
+
+            sample_files_map[sample_name] = sample_files
 
         return SnippyVariantsReader(sample_files_map=sample_files_map)

--- a/storage/variant/io/mutation/VariationFile.py
+++ b/storage/variant/io/mutation/VariationFile.py
@@ -1,6 +1,6 @@
 import tempfile
 from pathlib import Path
-from typing import List
+from typing import List, Tuple
 
 import pandas as pd
 from Bio import SeqIO
@@ -14,7 +14,7 @@ class VariationFile:
     def __init__(self, file: Path):
         self._file = file
 
-    def write(self, output: Path) -> Path:
+    def write(self, output: Path) -> Tuple[Path, Path]:
         if output.suffix == '.bcf':
             output_type = 'b'
         elif str(output).endswith('.vcf.gz'):
@@ -23,12 +23,14 @@ class VariationFile:
             raise Exception((f'Invalid file type [{output.suffix}] for output=[{output}]. '
                              'Must be one of [".bcf", ".vcf.bz"]'))
 
+        output_index = Path(str(output) + '.csi')
+
         execute_commands([
             ['bcftools', 'plugin', 'fill-tags', str(self._file), '-O', output_type, '-o', str(output),
              '--', '-t', 'TYPE'],
             ['bcftools', 'index', str(output)]
         ])
-        return output
+        return output, output_index
 
     def consensus(self, reference_file: Path, mask_file: Path = None, include_expression='TYPE="SNP"',
                   mask_with: str = 'N') -> List[SeqRecord]:

--- a/storage/variant/io/mutation/VcfVariantsReader.py
+++ b/storage/variant/io/mutation/VcfVariantsReader.py
@@ -7,12 +7,12 @@ import pandas as pd
 import vcf
 
 from storage.variant.MaskedGenomicRegions import MaskedGenomicRegions
-from storage.variant.io.mutation.NucleotideFeaturesReader import NucleotideFeaturesReader
-from storage.variant.io.mutation.NucleotideSampleFilesSequenceMask import NucleotideSampleFilesSequenceMask
-from storage.variant.io.mutation.NucleotideSampleFiles import NucleotideSampleFiles
 from storage.variant.io.SampleFiles import SampleFiles
-from storage.variant.io.processor.NullSampleFilesProcessor import NullSampleFilesProcessor
 from storage.variant.io.SampleFilesProcessor import SampleFilesProcessor
+from storage.variant.io.mutation.NucleotideFeaturesReader import NucleotideFeaturesReader
+from storage.variant.io.mutation.NucleotideSampleFiles import NucleotideSampleFiles
+from storage.variant.io.mutation.NucleotideSampleFilesSequenceMask import NucleotideSampleFilesSequenceMask
+from storage.variant.io.processor.NullSampleFilesProcessor import NullSampleFilesProcessor
 
 logger = logging.getLogger(__name__)
 

--- a/storage/variant/io/mutation/VcfVariantsReader.py
+++ b/storage/variant/io/mutation/VcfVariantsReader.py
@@ -104,28 +104,11 @@ class VcfVariantsReader(NucleotideFeaturesReader):
         """
         return str(element)
 
-    def _progress_hook(self, number: int, print_every: int, total: int) -> None:
-        if number % print_every == 0:
-            logger.info(f'Proccessed {number/total*100:0.0f}% ({number}/{total})')
-
-    def _read_genomic_masked_regions(self) -> Dict[str, MaskedGenomicRegions]:
-        genomic_masks = {}
-        num_samples = len(self._sample_vcf_map)
-        logger.info(f'Reading {num_samples} genomic masked regions')
-
-        processed = 0
-        interval = max(1, int(num_samples / 50))
-        for sample in self._sample_vcf_map:
-            self._progress_hook(processed, print_every=interval, total=num_samples)
-            if sample in self._genomic_mask_files_map:
-                genomic_masks[sample] = self.read_genomic_masks_from_file(self._genomic_mask_files_map[sample])
-            else:
-                genomic_masks[sample] = MaskedGenomicRegions.empty_mask()
-            processed += 1
-
-        logger.info(f'Finished reading {num_samples} genomic masked regions')
-
-        return genomic_masks
+    def get_genomic_masked_region(self, sample_name: str) -> MaskedGenomicRegions:
+        if sample_name in self._genomic_mask_files_map:
+            return self.read_genomic_masks_from_file(self._genomic_mask_files_map[sample_name])
+        else:
+            return MaskedGenomicRegions.empty_mask()
 
     def read_genomic_masks_from_file(self, file: Path) -> MaskedGenomicRegions:
         name, records = parse_sequence_file(file)

--- a/storage/variant/io/mutation/VcfVariantsReader.py
+++ b/storage/variant/io/mutation/VcfVariantsReader.py
@@ -38,9 +38,6 @@ class VcfVariantsReader(NucleotideFeaturesReader):
     def get_or_create_feature_file(self, sample_name: str):
         return self._sample_vcf_map[sample_name]
 
-    def sample_feature_files(self) -> Dict[str, Path]:
-        return self._sample_vcf_map
-
     def read_vcf(self, file: Path, sample_name: str) -> pd.DataFrame:
         reader = vcf.Reader(filename=str(file))
         df = pd.DataFrame([vars(r) for r in reader])

--- a/storage/variant/io/mutation/VcfVariantsReader.py
+++ b/storage/variant/io/mutation/VcfVariantsReader.py
@@ -98,6 +98,9 @@ class VcfVariantsReader(NucleotideFeaturesReader):
         """
         return str(element)
 
+    def persist_sample_files(self, sample_name: str, persistence_dir: Path) -> NucleotideSampleFiles:
+        return self._sample_files_map[sample_name].persist(persistence_dir)
+
     def get_genomic_masked_region(self, sample_name: str) -> MaskedGenomicRegions:
         return self._sample_files_map[sample_name].get_mask()
 

--- a/storage/variant/io/processor/MultipleProcessSampleFilesProcessor.py
+++ b/storage/variant/io/processor/MultipleProcessSampleFilesProcessor.py
@@ -1,7 +1,7 @@
-from typing import Dict
-from pathlib import Path
 import logging
 import multiprocessing as mp
+from pathlib import Path
+from typing import Dict
 
 from storage.variant.io.SampleFiles import SampleFiles
 from storage.variant.io.SampleFilesProcessor import SampleFilesProcessor

--- a/storage/variant/io/processor/MultipleProcessSampleFilesProcessor.py
+++ b/storage/variant/io/processor/MultipleProcessSampleFilesProcessor.py
@@ -1,0 +1,30 @@
+from typing import Dict
+from pathlib import Path
+import logging
+import multiprocessing as mp
+
+from storage.variant.io.SampleFiles import SampleFiles
+from storage.variant.io.SampleFilesProcessor import SampleFilesProcessor
+
+logger = logging.getLogger(__name__)
+
+
+class MultipleProcessSampleFilesProcessor(SampleFilesProcessor):
+
+    def __init__(self, preprocess_dir: Path, processing_cores: int):
+        super().__init__()
+        self._preprocess_dir = preprocess_dir
+        self._processing_cores = processing_cores
+
+    def handle_single_file(self, sample_files: SampleFiles) -> SampleFiles:
+        return sample_files.persist(self._preprocess_dir)
+
+    def preprocess_files(self) -> Dict[str, SampleFiles]:
+        processed_files = {}
+
+        with mp.Pool(self._processing_cores) as pool:
+            output_files = pool.map(self.handle_single_file, self.sample_files_list())
+            for entry in output_files:
+                processed_files[entry.sample_name] = entry
+
+        return processed_files

--- a/storage/variant/io/processor/MultipleProcessSampleFilesProcessor.py
+++ b/storage/variant/io/processor/MultipleProcessSampleFilesProcessor.py
@@ -22,9 +22,13 @@ class MultipleProcessSampleFilesProcessor(SampleFilesProcessor):
     def preprocess_files(self) -> Dict[str, SampleFiles]:
         processed_files = {}
 
+        logger.debug(f'Starting preprocessing {len(self.sample_files_list())} samples '
+                     f'with {self._processing_cores} cores')
         with mp.Pool(self._processing_cores) as pool:
             output_files = pool.map(self.handle_single_file, self.sample_files_list())
             for entry in output_files:
                 processed_files[entry.sample_name] = entry
+
+        logger.debug(f'Finished preprocessing {len(self.sample_files_list())} samples')
 
         return processed_files

--- a/storage/variant/io/processor/NullSampleFilesProcessor.py
+++ b/storage/variant/io/processor/NullSampleFilesProcessor.py
@@ -1,0 +1,17 @@
+from typing import Dict
+
+from storage.variant.io.SampleFiles import SampleFiles
+from storage.variant.io.SampleFilesProcessor import SampleFilesProcessor
+
+
+class NullSampleFilesProcessor(SampleFilesProcessor):
+
+    def __init__(self):
+        super().__init__()
+
+    def preprocess_files(self) -> Dict[str, SampleFiles]:
+        processed_files = {}
+        for sample_files in self.sample_files_list():
+            processed_files[sample_files.sample_name] = sample_files
+
+        return processed_files

--- a/storage/variant/io/processor/SerialSampleFilesProcessor.py
+++ b/storage/variant/io/processor/SerialSampleFilesProcessor.py
@@ -1,7 +1,6 @@
-import abc
-from typing import Dict
-from pathlib import Path
 import logging
+from pathlib import Path
+from typing import Dict
 
 from storage.variant.io.SampleFiles import SampleFiles
 from storage.variant.io.SampleFilesProcessor import SampleFilesProcessor

--- a/storage/variant/io/processor/SerialSampleFilesProcessor.py
+++ b/storage/variant/io/processor/SerialSampleFilesProcessor.py
@@ -1,0 +1,24 @@
+import abc
+from typing import Dict
+from pathlib import Path
+import logging
+
+from storage.variant.io.SampleFiles import SampleFiles
+from storage.variant.io.SampleFilesProcessor import SampleFilesProcessor
+
+logger = logging.getLogger(__name__)
+
+
+class SerialSampleFilesProcessor(SampleFilesProcessor):
+
+    def __init__(self, preprocess_dir: Path):
+        super().__init__()
+        self._preprocess_dir = preprocess_dir
+
+    def preprocess_files(self) -> Dict[str, SampleFiles]:
+        processed_files = {}
+        for sample_files in self.sample_files_list():
+            logger.debug(f'Pre-processing files for sample [{sample_files.sample_name}]')
+            processed_files[sample_files.sample_name] = sample_files.persist(self._preprocess_dir)
+
+        return processed_files

--- a/storage/variant/service/MLSTService.py
+++ b/storage/variant/service/MLSTService.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Dict, Set, Any, Tuple, cast
+from typing import Dict, Set, Any, Tuple, cast, List
 
 import pandas as pd
 
@@ -11,6 +11,7 @@ from storage.variant.model.db import MLSTScheme, SampleMLSTAlleles, MLSTAllelesS
 from storage.variant.service import DatabaseConnection
 from storage.variant.service.FeatureService import FeatureService, AUTO_SCOPE
 from storage.variant.service.SampleService import SampleService
+from storage.variant.io.SampleFiles import SampleFiles
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +92,7 @@ class MLSTService(FeatureService):
         return features_df
 
     def build_sample_feature_object(self, sample: Sample, features_reader: FeaturesReader,
+                                    sample_files: SampleFiles,
                                     feature_scope_name: str) -> Any:
         self._verify_correct_reader(features_reader=features_reader)
         mlst_reader = cast(MLSTFeaturesReader, features_reader)
@@ -104,3 +106,7 @@ class MLSTService(FeatureService):
         sample_mlst_alleles = SampleMLSTAlleles(sample=sample, scheme=mlst_scheme)
 
         return sample_mlst_alleles
+
+    def _create_persisted_features_reader(self, sample_files_dict: Dict[str, SampleFiles],
+                                          features_reader: FeaturesReader) -> FeaturesReader:
+        return features_reader

--- a/storage/variant/service/VariationService.py
+++ b/storage/variant/service/VariationService.py
@@ -82,13 +82,7 @@ class VariationService(FeatureService):
         sample_nucleotide_variation.nucleotide_variants_file = self._save_variation_file(feature_file, sample)
         sample_nucleotide_variation.sample = sample
 
-        genomic_masked_regions = variants_reader.get_genomic_masked_regions()
-
-        if sample.name in genomic_masked_regions:
-            masked_regions = genomic_masked_regions[sample.name]
-        else:
-            masked_regions = MaskedGenomicRegions.empty_mask()
-
+        masked_regions = variants_reader.get_genomic_masked_region(sample.name)
         sample_nucleotide_variation.masked_regions_file = self._save_masked_regions_file(masked_regions, sample)
 
         return sample_nucleotide_variation

--- a/storage/variant/service/VariationService.py
+++ b/storage/variant/service/VariationService.py
@@ -92,7 +92,8 @@ class VariationService(FeatureService):
         if new_file.exists():
             raise Exception(f'File {new_file} already exists')
 
-        return VariationFile(original_file).write(new_file)
+        saved_file, index_file = VariationFile(original_file).write(new_file)
+        return saved_file
 
     def _save_masked_regions_file(self, masked_regions, sample: Sample):
         new_file = self._features_dir / f'{sample.name}.bed.gz'

--- a/storage/variant/service/VariationService.py
+++ b/storage/variant/service/VariationService.py
@@ -27,7 +27,7 @@ class VariationService(FeatureService):
                          sample_service=sample_service)
         self._reference_service = reference_service
 
-    def get_variants_ordered(self, sequence_name: str, type: str = 'snp') -> List[NucleotideVariantsSamples]:
+    def get_variants_ordered(self, sequence_name: str, type: str = 'SNP') -> List[NucleotideVariantsSamples]:
         return self._connection.get_session().query(NucleotideVariantsSamples) \
             .filter(NucleotideVariantsSamples.sequence == sequence_name) \
             .filter(NucleotideVariantsSamples.var_type == type) \


### PR DESCRIPTION
Added support for parallel processing of input files.

The input files for nucleotide mutations all need to be pre-processed before saving (e.g., adding tags and compressing with BCFTools and creating BED file masks). This takes a long time with many files. So I refactored my code to use multiprocessing to do this in parallel. This also required refactoring how I am persisting the VCF/BED files and loading a table of mutations from them.